### PR TITLE
Quick fix in CryspyCalculator for objects of identical names

### DIFF
--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -1110,8 +1110,8 @@ class CryspyCalculator:
         return Pd(data_name=experiment['name'], background=backgrounds, resolution=resolution, meas=pattern,
                   phase=phases, setup=instrument)
 
-    def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float) -> NoReturn:
-        cryspyPhaseObj = cryspyPhase(label=phase_name, scale=scale)
+    def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float, igsize: float = 0.0) -> NoReturn:
+        cryspyPhaseObj = cryspyPhase(label=phase_name, scale=scale, igsize=igsize)
         idx = self._experiment_names.index(exp_name)
         self._cryspy_obj.experiments[idx].phase = PhaseL([cryspyPhaseObj, *self._cryspy_obj.experiments[idx].phase.item])
         self._log.info('Associated phase %s to experiment %s', phase_name, exp_name)

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -1,9 +1,10 @@
 import os
 
-from typing import Tuple
+from typing import Tuple, NoReturn, Optional
 
 import cryspy
 import pycifstar
+import random
 
 from asteval import Interpreter
 
@@ -113,7 +114,7 @@ class CryspyCalculator:
         self._log.debug('<---- End')
         return rcif_content
 
-    def setExpsDefinition(self, exp_path: str):
+    def setExpsDefinition(self, exp_path: str) -> NoReturn:
         self._log.debug('----> Start')
         """
         Set cryspy.experiments from a single file. *Removes all others*
@@ -142,7 +143,7 @@ class CryspyCalculator:
             self._cryspy_obj.experiments[0].phase.items[0] = (self._phase_name[0])
         self._log.debug('<---- End')
 
-    def addExpsDefinition(self, exp_path: str):
+    def addExpsDefinition(self, exp_path: str) -> NoReturn:
         self._log.debug('----> Start')
         """
         Add an experiment to cryspy.experiments
@@ -167,6 +168,11 @@ class CryspyCalculator:
             self._log.error('Experiment cif data is malformed')
         if self._cryspy_obj.experiments is not None:
             self._log.info('Adding experiment to cryspy experiments')
+            # Check for the same name and modify if exist
+            if experiment.data_name in self._experiment_name:
+                new_name = experiment.data_name + str(random.randint(0, 100))
+                self._log.warning(f'Experiment {experiment.data_name} exists, renaming to {new_name}')
+                experiment.data_name = new_name
             self._cryspy_obj.experiments = [*self._cryspy_obj.experiments, experiment]
         else:
             self._log.info('Experiment set from cif content')
@@ -174,7 +180,7 @@ class CryspyCalculator:
         self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.debug('<---- End')
 
-    def removeExpsDefinition(self, name: str):
+    def removeExpsDefinition(self, name: str) -> NoReturn:
         self._log.debug('----> Start')
         if name in self._experiment_name:
             self._log.info('Experiment found, removing')
@@ -187,7 +193,7 @@ class CryspyCalculator:
             raise KeyError
         self._log.debug('<---- End')
 
-    def setPhaseDefinition(self, phases_path: str):
+    def setPhaseDefinition(self, phases_path: str) -> NoReturn:
         self._log.debug('----> Start')
 
         """
@@ -232,7 +238,7 @@ class CryspyCalculator:
                 # self._cryspy_obj.experiments[0].phase.items[0] = (new_phase_name)
         self._log.debug('<---- End')
 
-    def addPhaseDefinition(self, phases_path: str):
+    def addPhaseDefinition(self, phases_path: str) -> NoReturn:
         self._log.debug('----> Start')
         """
         Parse the relevant phases file and update the corresponding model
@@ -256,6 +262,11 @@ class CryspyCalculator:
         phase = Crystal().from_cif(phases_rcif_content)
         if self._cryspy_obj.crystals is not None:
             self._log.info('Adding phase to existing phases')
+            # Check for the same name and modify if exist
+            if phase.data_name in self._phase_name:
+                new_name = phase.data_name + str(random.randint(0, 100))
+                self._log.warning(f'Phase {phase.data_name} exists, renaming to {new_name}')
+                phase.data_name = new_name
             self._cryspy_obj.crystals = [*self._cryspy_obj.crystals, phase]
         else:
             self._log.info('Setting cryspy crystal to phase')
@@ -263,7 +274,7 @@ class CryspyCalculator:
         self._phase_name = [phase.data_name for phase in self._cryspy_obj.crystals]
         self._log.debug('<---- End')
 
-    def removePhaseDefinition(self, name: str):
+    def removePhaseDefinition(self, name: str) -> NoReturn:
         self._log.debug('----> Start')
         if name in self._phase_name:
             crystals = self._cryspy_obj.crystals
@@ -282,7 +293,7 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def writeMainCif(self, save_dir: str, filename: str = 'main.cif', exp_name: str = 'experiments.cif',
-                     phase_name: str = 'phases.cif'):
+                     phase_name: str = 'phases.cif') -> NoReturn:
         self._log.debug('----> Start')
         self._log.info('Writing main cif file')
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
@@ -301,7 +312,7 @@ class CryspyCalculator:
             self._log.warning('No permission to write to %s', save_to)
         self._log.debug('<---- End')
 
-    def writePhaseCif(self, save_dir: str, phase_name: str = 'phases.cif'):
+    def writePhaseCif(self, save_dir: str, phase_name: str = 'phases.cif') -> NoReturn:
         self._log.debug('----> Start')
         save_to = os.path.join(save_dir, phase_name)
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
@@ -323,7 +334,7 @@ class CryspyCalculator:
             self._log.warning('No permission to write to %s', save_to)
         self._log.debug('<---- End')
 
-    def writeExpCif(self, save_dir: str, exp_name: str = 'experiments.cif'):
+    def writeExpCif(self, save_dir: str, exp_name: str = 'experiments.cif') -> NoReturn:
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
             self._log.warning('Cryspy object is malformed. Failure...')
             self._log.debug('<---- End')
@@ -344,7 +355,7 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def saveCifs(self, save_dir: str, filename: str = 'main.cif', exp_name: str = 'experiments.cif',
-                 phase_name: str = 'phases.cif'):
+                 phase_name: str = 'phases.cif') -> NoReturn:
         self._log.debug('----> Start')
         try:
             self.writeMainCif(save_dir, filename)
@@ -356,7 +367,7 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     @staticmethod
-    def _createProjItemFromObj(func, keys: list, obj_list: list):
+    def _createProjItemFromObj(func, keys: list, obj_list: list) -> list:
         """ ... """
         ret_vals = func(
             *[item.value if isinstance(item, cryspy.common.cl_fitable.Fitable) else item for item in obj_list])
@@ -383,7 +394,7 @@ class CryspyCalculator:
         self._log.info(phases)
         return phases
 
-    def readPhaseDefinition(self, phases_path):
+    def readPhaseDefinition(self, phases_path) -> Optional[Tuple[Phase, cpPhase]]:
         self._log.debug('----> Start')
 
         """
@@ -403,8 +414,8 @@ class CryspyCalculator:
         self._log.debug('<---- End')
         return phase, phase_cp
 
-    def _makePhase(self, calculator_phase: Crystal):
-        # This is ~180ms per atom in phase. Limited by cryspy 
+    def _makePhase(self, calculator_phase: Crystal) -> Phase:
+        # This is ~180ms per atom in phase. Limited by cryspy
         calculator_phase_name = calculator_phase.data_name
         # This group is < 1ms
         space_group = self._getPhasesSpace_group(calculator_phase_name)
@@ -413,7 +424,7 @@ class CryspyCalculator:
         # Atom sites ~ 6ms
         atoms = list(map(lambda x: self._makeAtom(calculator_phase, x), calculator_phase.atom_site.label))
         atoms = Atoms(atoms)
-        
+
         for key in atoms:
             phase['atoms'][key] = atoms[key]
 
@@ -421,7 +432,7 @@ class CryspyCalculator:
         self._makeAtomSites(phase, calculator_phase)
         return phase
 
-    def _makeAtom(self, calculator_phase: Crystal, label: str):
+    def _makeAtom(self, calculator_phase: Crystal, label: str) -> Atom:
         # This is ~2ms
         i = calculator_phase.atom_site.label.index(label)
         calculator_atom_site = calculator_phase.atom_site
@@ -433,7 +444,7 @@ class CryspyCalculator:
                 ii = len(self._cryspy_obj.crystals)
         else:
             # There are no crystals yet. assume that it will be added.
-            ii = 0  
+            ii = 0
         mapping_base = 'self._cryspy_obj.crystals'
         mapping_phase = mapping_base + '[{}]'.format(ii)
         mapping_atom = mapping_phase + '.atom_site'
@@ -526,7 +537,7 @@ class CryspyCalculator:
         return atom
 
     @staticmethod
-    def _makeAtomSites(phase: Phase, calculator_phase: Crystal):
+    def _makeAtomSites(phase: Phase, calculator_phase: Crystal) -> NoReturn:
         atom_site_list = [[], [], [], []]
         # Atom sites for structure view (all the positions inside unit cell of 1x1x1)
         for x, y, z, scat_length_neutron in zip(calculator_phase.atom_site.fract_x,
@@ -583,7 +594,7 @@ class CryspyCalculator:
         space_group['origin_choice']['mapping'] = mapping_phase + '.space_group.it_coordinate_system_code'
         return space_group
 
-    def _getPhaseCell(self, phase_name:str) -> Cell:
+    def _getPhaseCell(self, phase_name: str) -> Cell:
         mapping_base = 'self._cryspy_obj.crystals'
         i = self._phase_name.index(phase_name)
         calculator_phase = self._cryspy_obj.crystals[i]
@@ -781,14 +792,14 @@ class CryspyCalculator:
         return calculations
 
     @staticmethod
-    def _setCalculatorObjFromProjectDict(item: cryspy.common.cl_fitable.Fitable, data: Base):
+    def _setCalculatorObjFromProjectDict(item: cryspy.common.cl_fitable.Fitable, data: Base) -> NoReturn:
         if not isinstance(item, cryspy.common.cl_fitable.Fitable):
             return
         item.value = data.value
         item.refinement = data['store']['refine']
 
     @staticmethod
-    def _createProjDictFromObj(item: 'PathDict', obj: cryspy.common.cl_fitable.Fitable):
+    def _createProjDictFromObj(item: 'PathDict', obj: cryspy.common.cl_fitable.Fitable) -> NoReturn:
         """ ... """
         item.setItemByPath(['store', 'value'], obj)
         if not isinstance(obj, cryspy.common.cl_fitable.Fitable):
@@ -799,7 +810,7 @@ class CryspyCalculator:
         item.setItemByPath(['store', 'hide'], obj.value)
         item.setItemByPath(['store', 'refine'], obj.value)
 
-    def setPhases(self, phases: Phases):
+    def setPhases(self, phases: Phases) -> NoReturn:
         """Set phases (sample model tab in GUI)"""
         self._log.info('-> start')
         self._cryspy_obj.crystals = []
@@ -807,7 +818,7 @@ class CryspyCalculator:
             self.addPhase(phases[phase_name])
         self._log.info('<- end')
 
-    def setExperiments(self, experiments: Experiments):
+    def setExperiments(self, experiments: Experiments) -> NoReturn:
         """Set experiments (Experimental data tab in GUI)"""
         self._log.info('-> start')
         self._cryspy_obj.experiments = []
@@ -815,7 +826,7 @@ class CryspyCalculator:
             self.addExperiment(experiments[experiment_name])
         self._log.info('<- end')
 
-    def setObjFromProjectDicts(self, phases: Phases, experiments: Experiments):
+    def setObjFromProjectDicts(self, phases: Phases, experiments: Experiments) -> NoReturn:
         """Set all the cryspy parameters from project dictionary"""
         self.setPhases(phases)
         self.setExperiments(experiments)
@@ -840,7 +851,7 @@ class CryspyCalculator:
         }
 
     @time_it
-    def refine(self):
+    def refine(self) -> Tuple[dict, dict]:
         """refinement ..."""
         refinement_res = self._cryspy_obj.refine()
         scipy_refinement_res = refinement_res['res']
@@ -862,12 +873,12 @@ class CryspyCalculator:
         chi_sq, n_res = self.getChiSq()
         return chi_sq / n_res
 
-    def _mappedValueUpdater(self, item_str, value):
+    def _mappedValueUpdater(self, item_str, value) -> NoReturn:
         aeval = Interpreter(usersyms=dict(self=self))
         item = aeval(item_str)
         item.value = value
 
-    def _mappedRefineUpdater(self, item_str, value):
+    def _mappedRefineUpdater(self, item_str, value) -> NoReturn:
         aeval = Interpreter(usersyms=dict(self=self))
         item = aeval(item_str)
         item.refinement = value
@@ -883,7 +894,7 @@ class CryspyCalculator:
         return self._phase_name
 
     @time_it
-    def addPhase(self, phase: Phase):
+    def addPhase(self, phase: Phase) -> NoReturn:
         phase_obj = self._createPhaseObj(phase)
         if self._cryspy_obj.crystals is not None:
             self._cryspy_obj.crystals = [phase_obj, *self._cryspy_obj.crystals]
@@ -893,7 +904,7 @@ class CryspyCalculator:
         self._cryspy_obj.apply_constraint()
 
     @time_it
-    def addExperiment(self, experiment: Experiment):
+    def addExperiment(self, experiment: Experiment) -> NoReturn:
         exp_obj = self._createExperimentObj(experiment)
         if self._cryspy_obj.experiments is not None:
             self._cryspy_obj.experiments = [exp_obj, *self._cryspy_obj.experiments]
@@ -902,7 +913,7 @@ class CryspyCalculator:
         self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
 
     @staticmethod
-    def _createPhaseObj(phase: Phase):
+    def _createPhaseObj(phase: Phase) -> Crystal:
         this_cell = cpCell(length_a=phase['cell']['length_a'].value,
                            length_b=phase['cell']['length_b'].value,
                            length_c=phase['cell']['length_c'].value,
@@ -954,7 +965,7 @@ class CryspyCalculator:
         return phase_obj
 
     @staticmethod
-    def _createExperimentObj(experiment: Experiment):
+    def _createExperimentObj(experiment: Experiment) -> Pd:
         # First create a background
         backgrounds = PdBackgroundL(
             list(
@@ -1010,13 +1021,13 @@ class CryspyCalculator:
         return Pd(data_name=experiment['name'], background=backgrounds, resolution=resolution, meas=pattern,
                   phase=phases, setup=instrument)
 
-    def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float):
+    def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float) -> NoReturn:
         cryspyPhase = cpPhase(label=phase_name, scale=scale)
         idx = self._experiment_name.index(exp_name)
         self._cryspy_obj.experiments[idx].phase = PhaseL([cryspyPhase, *self._cryspy_obj.experiments[idx].phase.item])
         self._log.info('Associated phase %s to experiment %s', phase_name, exp_name)
 
-    def disassociatePhaseToExp(self, exp_name: str, phase_name: str):
+    def disassociatePhaseToExp(self, exp_name: str, phase_name: str) -> NoReturn:
         idx = self._experiment_name.index(exp_name)
         exp_phases = self._cryspy_obj.experiments[idx].phase
         exp_phases = PhaseL(

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -4,7 +4,6 @@ from typing import Tuple, NoReturn, Optional
 
 import cryspy
 import pycifstar
-import random
 
 from asteval import Interpreter
 
@@ -41,7 +40,7 @@ CALCULATOR_INFO = {
 
 
 class CryspyCalculator:
-    def __init__(self, main_rcif_path: Union[str, type(None)] = None):
+    def __init__(self, main_rcif_path: Union[str, type(None)] = None) -> None:
         self._log = logging.getLogger(__class__.__module__)
         self._experiment_name = []
         self._main_rcif_path = main_rcif_path
@@ -115,10 +114,10 @@ class CryspyCalculator:
         return rcif_content
 
     def setExpsDefinition(self, exp_path: str) -> NoReturn:
-        self._log.debug('----> Start')
         """
         Set cryspy.experiments from a single file. *Removes all others*
         """
+        self._log.debug('----> Start')
         rcif_content = ""
         if not isinstance(exp_path, (str, os.PathLike)):
             self._log.warning('Experiment definition is not a string or path')
@@ -146,10 +145,10 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def addExpDefinitionFromString(self, exp_rcif_content: str) -> NoReturn:
-        self._log.debug('----> Start')
         """
         Set cryspy.experiments from a string. Appends to current experiments if available.
         """
+        self._log.debug('----> Start')
         experiment = Pd.from_cif(exp_rcif_content)
         if experiment is None:
             self._log.error('Experiment cif data is malformed')
@@ -161,10 +160,10 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def addExpsDefinition(self, exp_path: str) -> NoReturn:
-        self._log.debug('----> Start')
         """
         Add an experiment to cryspy.experiments
         """
+        self._log.debug('----> Start')
         if not isinstance(exp_path, (str, os.PathLike)):
             self._log.warning('Experiment definition is not a string or path')
             return
@@ -187,7 +186,11 @@ class CryspyCalculator:
             self._log.info('Adding experiment to cryspy experiments')
             # Check for the same name and modify if exist
             if experiment.data_name in self._experiment_name:
-                new_name = experiment.data_name + str(random.randint(0, 100))
+                index = 0
+                new_name = experiment.data_name
+                while new_name in self._experiment_name:
+                    new_name = experiment.data_name + str(index)
+                    index += 1
                 self._log.warning(f'Experiment {experiment.data_name} exists, renaming to {new_name}')
                 experiment.data_name = new_name
             self._cryspy_obj.experiments = [*self._cryspy_obj.experiments, experiment]
@@ -211,11 +214,10 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def setPhaseDefinition(self, phases_path: str) -> NoReturn:
-        self._log.debug('----> Start')
-
         """
         Parse the relevant phases file and update the corresponding model
         """
+        self._log.debug('----> Start')
         rcif_content = ""
         if not isinstance(phases_path, (str, os.PathLike)):
             self._log.warning('Phase definition is not a string or path')
@@ -256,10 +258,10 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def addPhaseDefinition(self, phases_path: str) -> NoReturn:
-        self._log.debug('----> Start')
         """
         Parse the relevant phases file and update the corresponding model
         """
+        self._log.debug('----> Start')
         if not isinstance(phases_path, (str, os.PathLike)):
             self._log.warning('Phase definition is not a string or path')
             return
@@ -281,7 +283,11 @@ class CryspyCalculator:
             self._log.info('Adding phase to existing phases')
             # Check for the same name and modify if exist
             if phase.data_name in self._phase_name:
-                new_name = phase.data_name + str(random.randint(0, 100))
+                index = 0
+                new_name = phase.data_name
+                while new_name == self._experiment_name:
+                    new_name = phase.data_name + '_' + str(index)
+                    index += 1
                 self._log.warning(f'Phase {phase.data_name} exists, renaming to {new_name}')
                 phase.data_name = new_name
             self._cryspy_obj.crystals = [*self._cryspy_obj.crystals, phase]
@@ -412,11 +418,10 @@ class CryspyCalculator:
         return phases
 
     def readPhaseDefinition(self, phases_path) -> Optional[Tuple[Phase, cpPhase]]:
-        self._log.debug('----> Start')
-
         """
         Parse the relevant phases file and update the corresponding model
         """
+        self._log.debug('----> Start')
         phases_rcif_content = ""
         if not isinstance(phases_path, (str, os.PathLike)):
             self._log.warning('Phase definition is not a string or path')

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -1,42 +1,47 @@
-import os
+#  Licensed under the GNU General Public License v3.0
+#  Copyright (c) of the author (github.com/wardsimon)
+#  Created: 12/3/2020
 
-from typing import Tuple, NoReturn, Optional
+import os
+from typing import Tuple, Optional
 
 import cryspy
 import pycifstar
-
 from asteval import Interpreter
+from cryspy.cif_like.cl_crystal import Crystal
+from cryspy.cif_like.cl_pd import Pd, PdBackground, PdBackgroundL, PdInstrResolution, PdMeas, PdMeasL, PhaseL, Setup
+from cryspy.cif_like.cl_pd import Phase as cryspyPhase
+from cryspy.corecif.cl_atom_site import AtomSite, AtomSiteL
+from cryspy.corecif.cl_atom_site_aniso import AtomSiteAniso, AtomSiteAnisoL
+# Imports needed to create a phase
+from cryspy.corecif.cl_cell import Cell as cryspyCell
+from cryspy.magneticcif.cl_atom_site_susceptibility import AtomSiteSusceptibility, AtomSiteSusceptibilityL
+## Start cryspy imports
+# Imports needed to create a cryspyObj
+from cryspy.scripts.cl_rhochi import RhoChi
+from cryspy.symcif.cl_space_group import SpaceGroup as cpSpaceGroup
 
+from easyInterface import logger as logging
 from easyInterface.Diffraction.DataClasses.DataObj.Calculation import *
 from easyInterface.Diffraction.DataClasses.DataObj.Experiment import *
 from easyInterface.Diffraction.DataClasses.PhaseObj.Phase import *
 from easyInterface.Diffraction.DataClasses.Utils.BaseClasses import Base
-
 from easyInterface.Utils.Helpers import time_it
 
-# Imports needed to create a cryspyObj
-from cryspy.scripts.cl_rhochi import RhoChi
-from cryspy.cif_like.cl_crystal import Crystal
-from cryspy.cif_like.cl_pd import Phase as cryspyPhase
-from cryspy.cif_like.cl_pd import Pd, PdBackground, PdBackgroundL, PdInstrResolution, PdMeas, PdMeasL, PhaseL, Setup
-
-# Imports needed to create a phase
-from cryspy.corecif.cl_cell import Cell as cryspyCell
-from cryspy.corecif.cl_atom_site import AtomSite, AtomSiteL
-from cryspy.corecif.cl_atom_site_aniso import AtomSiteAniso, AtomSiteAnisoL
-from cryspy.magneticcif.cl_atom_site_susceptibility import AtomSiteSusceptibility, AtomSiteSusceptibilityL
-from cryspy.symcif.cl_space_group import SpaceGroup as cpSpaceGroup
-
-from easyInterface import logger as logging
+# Version info
+cryspy_version = 'Undefined'
+try:
+    from cryspy import __version__ as cryspy_version
+except ImportError:
+    logging.logger.info('Can not find cryspy version. Using default text')
+CALCULATOR_INFO = {
+    'name': 'CrysPy',
+    'version': cryspy_version,
+    'url': 'https://github.com/ikibalin/cryspy'
+}
 
 PHASE_SEGMENT = "_phases"
 EXPERIMENT_SEGMENT = "_experiments"
-
-CALCULATOR_INFO = {
-    'name': 'CrysPy',
-    'version': '0.2.0',
-    'url': 'https://github.com/ikibalin/cryspy'
-}
 
 
 class CryspyCalculator:
@@ -223,7 +228,8 @@ class CryspyCalculator:
         if experiment_name in self._experiment_names:
             self._log.info('Experiment found, removing')
             experiments = self._cryspy_obj.experiments
-            self._cryspy_obj.experiments = [experiment for experiment in experiments if experiment.data_name != experiment_name]
+            self._cryspy_obj.experiments = [experiment for experiment in experiments if
+                                            experiment.data_name != experiment_name]
             self._experiment_names = []
             if self._cryspy_obj.experiments:
                 self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
@@ -1113,7 +1119,8 @@ class CryspyCalculator:
     def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float, igsize: float = 0.0) -> NoReturn:
         cryspyPhaseObj = cryspyPhase(label=phase_name, scale=scale, igsize=igsize)
         idx = self._experiment_names.index(exp_name)
-        self._cryspy_obj.experiments[idx].phase = PhaseL([cryspyPhaseObj, *self._cryspy_obj.experiments[idx].phase.item])
+        self._cryspy_obj.experiments[idx].phase = PhaseL(
+            [cryspyPhaseObj, *self._cryspy_obj.experiments[idx].phase.item])
         self._log.info('Associated phase %s to experiment %s', phase_name, exp_name)
 
     def disassociatePhaseFromExp(self, exp_name: str, phase_name: str) -> NoReturn:

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -136,11 +136,28 @@ class CryspyCalculator:
             return
 
         experiment = Pd.from_cif(exp_rcif_content)
+        if experiment is None:
+            self._log.error('Experiment cif data is malformed')
         self._cryspy_obj.experiments = [experiment]
         self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.info('Setting cryspy experiments from cif content')
         if self._cryspy_obj.crystals is not None:
             self._cryspy_obj.experiments[0].phase.items[0] = (self._phase_name[0])
+        self._log.debug('<---- End')
+
+    def addExpDefinitionFromString(self, exp_rcif_content: str) -> NoReturn:
+        self._log.debug('----> Start')
+        """
+        Set cryspy.experiments from a string. Appends to current experiments if available.
+        """
+        experiment = Pd.from_cif(exp_rcif_content)
+        if experiment is None:
+            self._log.error('Experiment cif data is malformed')
+        if self._cryspy_obj.experiments is None:
+            self._cryspy_obj.experiments = [experiment]
+        else:
+            self._cryspy_obj.experiments = [*self._cryspy_obj.experiments, experiment]
+        self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.debug('<---- End')
 
     def addExpsDefinition(self, exp_path: str) -> NoReturn:

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -333,6 +333,8 @@ class CryspyCalculator:
             main_block.to_file(save_to)
         except PermissionError:
             self._log.warning('No permission to write to %s', save_to)
+        except AttributeError:
+            self._log.warning('No information stored in the object. Saving failed')
         self._log.debug('<---- End')
 
     def writePhaseCif(self, save_dir: str, phase_name: str = 'phases.cif') -> NoReturn:

--- a/easyInterface/Diffraction/Calculators/CryspyCalculator.py
+++ b/easyInterface/Diffraction/Calculators/CryspyCalculator.py
@@ -17,11 +17,11 @@ from easyInterface.Utils.Helpers import time_it
 # Imports needed to create a cryspyObj
 from cryspy.scripts.cl_rhochi import RhoChi
 from cryspy.cif_like.cl_crystal import Crystal
-from cryspy.cif_like.cl_pd import Phase as cpPhase
+from cryspy.cif_like.cl_pd import Phase as cryspyPhase
 from cryspy.cif_like.cl_pd import Pd, PdBackground, PdBackgroundL, PdInstrResolution, PdMeas, PdMeasL, PhaseL, Setup
 
 # Imports needed to create a phase
-from cryspy.corecif.cl_cell import Cell as cpCell
+from cryspy.corecif.cl_cell import Cell as cryspyCell
 from cryspy.corecif.cl_atom_site import AtomSite, AtomSiteL
 from cryspy.corecif.cl_atom_site_aniso import AtomSiteAniso, AtomSiteAnisoL
 from cryspy.magneticcif.cl_atom_site_susceptibility import AtomSiteSusceptibility, AtomSiteSusceptibilityL
@@ -42,11 +42,11 @@ CALCULATOR_INFO = {
 class CryspyCalculator:
     def __init__(self, main_rcif_path: Union[str, type(None)] = None) -> None:
         self._log = logging.getLogger(__class__.__module__)
-        self._experiment_name = []
+        self._experiment_names = []
         self._main_rcif_path = main_rcif_path
         self._main_rcif = None
         self._phases_path = ""
-        self._phase_name = []
+        self._phase_names = []
         self._experiments_path = ""
         self._cryspy_obj = self._createCryspyObj()
         self._log.info('Created cryspy calculator interface')
@@ -68,7 +68,12 @@ class CryspyCalculator:
         except TypeError:
             self._log.warning('Main cif location is not a path')
             return RhoChi()
-        full_rcif_content = self._parseSegment(EXPERIMENT_SEGMENT) + phase_segment
+        try:
+            exp_segment = self._parseSegment(EXPERIMENT_SEGMENT)
+        except TypeError:
+            self._log.warning('Main cif location is not a path')
+            return RhoChi()
+        full_rcif_content = exp_segment + phase_segment
         # update the phase name global
         self._log.debug('Calling RhoChi')
         rho_chi = RhoChi().from_cif(full_rcif_content)
@@ -77,8 +82,8 @@ class CryspyCalculator:
             rho_chi = RhoChi()
         else:
             self._log.debug('Populating _phase_name with cryspy phase names')
-            self._phase_name = [phase.data_name for phase in rho_chi.crystals]
-            self._experiment_name = [experiment.data_name for experiment in rho_chi.experiments]
+            self._phase_names = [phase.data_name for phase in rho_chi.crystals]
+            self._experiment_names = [experiment.data_name for experiment in rho_chi.experiments]
         self._log.debug('<---- End')
         return rho_chi
 
@@ -115,10 +120,13 @@ class CryspyCalculator:
 
     def setExpsDefinition(self, exp_path: str) -> NoReturn:
         """
-        Set cryspy.experiments from a single file. *Removes all others*
+        Set an experiment/s to be simulated from a cif file. Note that this will not have any crystallographic phases
+        associated with it.
+
+        :param exp_path: Path to a experiment file (`.cif`)
         """
         self._log.debug('----> Start')
-        rcif_content = ""
+        exp_rcif_content = ""
         if not isinstance(exp_path, (str, os.PathLike)):
             self._log.warning('Experiment definition is not a string or path')
             return
@@ -128,7 +136,6 @@ class CryspyCalculator:
             with open(exp_path, 'r') as f:
                 self._log.debug('Reading experiment cif file')
                 exp_rcif_content = f.read()
-                rcif_content += exp_rcif_content
             self._experiments_path = exp_path
         else:
             self._log.warning('Experiment cif can not be found')
@@ -138,15 +145,18 @@ class CryspyCalculator:
         if experiment is None:
             self._log.error('Experiment cif data is malformed')
         self._cryspy_obj.experiments = [experiment]
-        self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
+        self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.info('Setting cryspy experiments from cif content')
         if self._cryspy_obj.crystals is not None:
-            self._cryspy_obj.experiments[0].phase.items[0] = (self._phase_name[0])
+            self._cryspy_obj.experiments[0].phase.items[0] = (self._phase_names[0])
         self._log.debug('<---- End')
 
     def addExpDefinitionFromString(self, exp_rcif_content: str) -> NoReturn:
         """
-        Set cryspy.experiments from a string. Appends to current experiments if available.
+        Set an experiment/s to be simulated from a string. Note that this will not have any crystallographic phases
+        associated with it.
+
+        :param exp_rcif_content: String containing the contents of an experiment file (`.cif`)
         """
         self._log.debug('----> Start')
         experiment = Pd.from_cif(exp_rcif_content)
@@ -156,12 +166,15 @@ class CryspyCalculator:
             self._cryspy_obj.experiments = [experiment]
         else:
             self._cryspy_obj.experiments = [*self._cryspy_obj.experiments, experiment]
-        self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
+        self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.debug('<---- End')
 
     def addExpsDefinition(self, exp_path: str) -> NoReturn:
         """
-        Add an experiment to cryspy.experiments
+        Add an experiment to be simulated from a cif file. Note that this will not have any crystallographic phases
+        associated with it.
+
+        :param exp_path: Path to a experiment file (`.cif`)
         """
         self._log.debug('----> Start')
         if not isinstance(exp_path, (str, os.PathLike)):
@@ -185,10 +198,10 @@ class CryspyCalculator:
         if self._cryspy_obj.experiments is not None:
             self._log.info('Adding experiment to cryspy experiments')
             # Check for the same name and modify if exist
-            if experiment.data_name in self._experiment_name:
+            if experiment.data_name in self._experiment_names:
                 index = 0
                 new_name = experiment.data_name
-                while new_name in self._experiment_name:
+                while new_name in self._experiment_names:
                     new_name = experiment.data_name + str(index)
                     index += 1
                 self._log.warning(f'Experiment {experiment.data_name} exists, renaming to {new_name}')
@@ -197,25 +210,32 @@ class CryspyCalculator:
         else:
             self._log.info('Experiment set from cif content')
             self._cryspy_obj.experiments = [experiment]
-        self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
+        self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         self._log.debug('<---- End')
 
-    def removeExpsDefinition(self, name: str) -> NoReturn:
+    def removeExpsDefinition(self, experiment_name: str) -> NoReturn:
+        """
+        Remove a experiment from both the project dictionary and the calculator.
+
+        :param experiment_name: Name of the experiment to be removed.
+        """
         self._log.debug('----> Start')
-        if name in self._experiment_name:
+        if experiment_name in self._experiment_names:
             self._log.info('Experiment found, removing')
             experiments = self._cryspy_obj.experiments
-            self._cryspy_obj.experiments = [experiment for experiment in experiments if experiment.data_name != name]
-            self._experiment_name = []
+            self._cryspy_obj.experiments = [experiment for experiment in experiments if experiment.data_name != experiment_name]
+            self._experiment_names = []
             if self._cryspy_obj.experiments:
-                self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
+                self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
         else:
             raise KeyError
         self._log.debug('<---- End')
 
     def setPhaseDefinition(self, phases_path: str) -> NoReturn:
         """
-        Parse the relevant phases file and update the corresponding model
+        Parse a phases cif file and replace existing crystal phases
+
+        :param phases_path: Path to new phase definition file  (`.cif`)
         """
         self._log.debug('----> Start')
         rcif_content = ""
@@ -238,7 +258,7 @@ class CryspyCalculator:
         phase = Crystal().from_cif(phases_rcif_content)
         new_phase_name = phase.data_name
         self._cryspy_obj.crystals = [phase]
-        self._phase_name = [phase.data_name for phase in self._cryspy_obj.crystals]
+        self._phase_names = [phase.data_name for phase in self._cryspy_obj.crystals]
 
         experiment_segment = ''
         if self._cryspy_obj.experiments is not None:
@@ -259,7 +279,9 @@ class CryspyCalculator:
 
     def addPhaseDefinition(self, phases_path: str) -> NoReturn:
         """
-        Parse the relevant phases file and update the corresponding model
+        Add new phases from a cif file to the list of existing crystal phases in the calculator.
+
+        :param phases_path: Path to a phase definition file (`.cif`)
         """
         self._log.debug('----> Start')
         if not isinstance(phases_path, (str, os.PathLike)):
@@ -282,10 +304,10 @@ class CryspyCalculator:
         if self._cryspy_obj.crystals is not None:
             self._log.info('Adding phase to existing phases')
             # Check for the same name and modify if exist
-            if phase.data_name in self._phase_name:
+            if phase.data_name in self._phase_names:
                 index = 0
                 new_name = phase.data_name
-                while new_name == self._experiment_name:
+                while new_name == self._experiment_names:
                     new_name = phase.data_name + '_' + str(index)
                     index += 1
                 self._log.warning(f'Phase {phase.data_name} exists, renaming to {new_name}')
@@ -294,29 +316,43 @@ class CryspyCalculator:
         else:
             self._log.info('Setting cryspy crystal to phase')
             self._cryspy_obj.crystals = [phase]
-        self._phase_name = [phase.data_name for phase in self._cryspy_obj.crystals]
+        self._phase_names = [phase.data_name for phase in self._cryspy_obj.crystals]
         self._log.debug('<---- End')
 
-    def removePhaseDefinition(self, name: str) -> NoReturn:
+    def removePhaseDefinition(self, phase_name: str) -> NoReturn:
+        """
+        Remove a phase of a given name from the calculator object.
+
+        :param phase_name: name of the phase to be removed.
+        """
         self._log.debug('----> Start')
-        if name in self._phase_name:
+        if phase_name in self._phase_names:
             crystals = self._cryspy_obj.crystals
-            self._cryspy_obj.crystals = [crystal for crystal in crystals if crystal.data_name != name]
-            self._phase_name = []
+            self._cryspy_obj.crystals = [crystal for crystal in crystals if crystal.data_name != phase_name]
+            self._phase_names = []
             if self._cryspy_obj.crystals:
-                self._phase_name = [phase.data_name for phase in self._cryspy_obj.crystals]
-            self._log.info('Removing phase %s', name)
+                self._phase_names = [phase.data_name for phase in self._cryspy_obj.crystals]
+            self._log.info('Removing phase %s', phase_name)
         else:
             self._log.warning('Phase not found in cryspy crystals')
             raise KeyError
         # See if this is associated to an experiment....
         for experiment in self._cryspy_obj.experiments:
-            if name in self.getPhasesAssocatedToExp(experiment.data_name):
-                self.disassociatePhaseToExp(experiment.data_name, name)
+            if phase_name in self.getPhasesAssocatedToExp(experiment.data_name):
+                self.disassociatePhaseFromExp(experiment.data_name, phase_name)
         self._log.debug('<---- End')
 
-    def writeMainCif(self, save_dir: str, filename: str = 'main.cif', exp_name: str = 'experiments.cif',
-                     phase_name: str = 'phases.cif') -> NoReturn:
+    def writeMainCif(self, save_dir: str, filename: str = 'main.cif', exp_filename: str = 'experiments.cif',
+                     phase_filename: str = 'phases.cif') -> NoReturn:
+        """
+        Write the `main.cif` where links to the experiments and phases are stored and other generalised project
+        information.
+
+        :param phase_filename: What to call the phases file.
+        :param exp_filename: What to call the experiments file.
+        :param filename:  What to call the main file.
+        :param save_dir: Directory to where the main cif file should be saved.
+        """
         self._log.debug('----> Start')
         self._log.info('Writing main cif file')
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
@@ -326,9 +362,9 @@ class CryspyCalculator:
         main_block = self._main_rcif
         save_to = os.path.join(save_dir, filename)
         if self._cryspy_obj.crystals is not None:
-            main_block["_phases"].value = phase_name
+            main_block["_phases"].value = phase_filename
         if self._cryspy_obj.experiments is not None:
-            main_block["_experiments"].value = exp_name
+            main_block["_experiments"].value = exp_filename
         try:
             main_block.to_file(save_to)
         except PermissionError:
@@ -338,6 +374,13 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def writePhaseCif(self, save_dir: str, phase_name: str = 'phases.cif') -> NoReturn:
+        """
+        Write the `phases.cif` where all phases in the calculator are saved to file. This cif file should be
+        compatible with other crystallographic software.
+
+        :param phase_name: What to call the phases file.
+        :param save_dir: Directory to where the phases cif file should be saved.
+        """
         self._log.debug('----> Start')
         save_to = os.path.join(save_dir, phase_name)
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
@@ -360,6 +403,13 @@ class CryspyCalculator:
         self._log.debug('<---- End')
 
     def writeExpCif(self, save_dir: str, exp_name: str = 'experiments.cif') -> NoReturn:
+        """
+        Write the `experiments.cif` where all experiments in the calculator are saved to file. This includes the
+        instrumental parameters and which phases are in the experiment/s
+
+        :param exp_name: What to call the experiments file.
+        :param save_dir: Directory to where the experiment cif file should be saved.
+        """
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi):
             self._log.warning('Cryspy object is malformed. Failure...')
             self._log.debug('<---- End')
@@ -381,6 +431,15 @@ class CryspyCalculator:
 
     def saveCifs(self, save_dir: str, filename: str = 'main.cif', exp_name: str = 'experiments.cif',
                  phase_name: str = 'phases.cif') -> NoReturn:
+        """
+        Write project cif files (`main.cif`, `experiments.cif` and `phases.cif`) to a user supplied directory. This
+        contains all information needed to recreate the calculator object.
+
+        :param phase_name: What to call the phases file.
+        :param exp_name: What to call the experiments file.
+        :param filename:  What to call the main file.
+        :param save_dir: Directory to where the main cif file should be saved.
+        """
         self._log.debug('----> Start')
         try:
             self.writeMainCif(save_dir, filename)
@@ -408,8 +467,9 @@ class CryspyCalculator:
 
     @time_it
     def getPhases(self) -> Phases:
-        """Set phases (sample model tab in GUI)"""
-
+        """
+        Returns all phases from the calculator object.
+        """
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi) or self._cryspy_obj.crystals is None:
             return Phases({})
 
@@ -419,7 +479,7 @@ class CryspyCalculator:
         self._log.info(phases)
         return phases
 
-    def readPhaseDefinition(self, phases_path) -> Optional[Tuple[Phase, cpPhase]]:
+    def readPhaseDefinition(self, phases_path) -> Optional[Tuple[Phase, cryspyPhase]]:
         """
         Parse the relevant phases file and update the corresponding model
         """
@@ -433,7 +493,7 @@ class CryspyCalculator:
         if os.path.isfile(phases_path):
             with open(phases_path, 'r') as f:
                 phases_rcif_content = f.read()
-        phase_cp = cpPhase().from_cif(phases_rcif_content)
+        phase_cp = cryspyPhase().from_cif(phases_rcif_content)
         phase = self._makePhase(phase_cp)
         self._log.debug('<---- End')
         return phase, phase_cp
@@ -442,7 +502,7 @@ class CryspyCalculator:
         # This is ~180ms per atom in phase. Limited by cryspy
         calculator_phase_name = calculator_phase.data_name
         # This group is < 1ms
-        space_group = self._getPhasesSpace_group(calculator_phase_name)
+        space_group = self._getPhasesSpaceGroup(calculator_phase_name)
         unit_cell = self._getPhaseCell(calculator_phase_name)
         phase = Phase.fromPars(calculator_phase_name, space_group, unit_cell)
         # Atom sites ~ 6ms
@@ -458,88 +518,88 @@ class CryspyCalculator:
 
     def _makeAtom(self, calculator_phase: Crystal, label: str) -> Atom:
         # This is ~2ms
-        i = calculator_phase.atom_site.label.index(label)
+        site_index = calculator_phase.atom_site.label.index(label)
         calculator_atom_site = calculator_phase.atom_site
         if self._cryspy_obj.crystals is not None:
             try:
-                ii = self._cryspy_obj.crystals.index(calculator_phase)
+                crystal_index = self._cryspy_obj.crystals.index(calculator_phase)
             except ValueError:
                 # Phase has not been added to crystal. Assume that it will be, possibly in error :-/
-                ii = len(self._cryspy_obj.crystals)
+                crystal_index = len(self._cryspy_obj.crystals)
         else:
             # There are no crystals yet. assume that it will be added.
-            ii = 0
+            crystal_index = 0
         mapping_base = 'self._cryspy_obj.crystals'
-        mapping_phase = mapping_base + '[{}]'.format(ii)
+        mapping_phase = mapping_base + '[{}]'.format(crystal_index)
         mapping_atom = mapping_phase + '.atom_site'
 
         # Atom sites symbol
-        type_symbol = calculator_atom_site.type_symbol[i]
+        type_symbol = calculator_atom_site.type_symbol[site_index]
 
         # Atom site neutron scattering length
-        scat_length_neutron = calculator_atom_site.scat_length_neutron[i]
+        scat_length_neutron = calculator_atom_site.scat_length_neutron[site_index]
 
         # Atom site coordinates
-        fract_x = calculator_atom_site.fract_x[i]
-        fract_y = calculator_atom_site.fract_y[i]
-        fract_z = calculator_atom_site.fract_z[i]
+        fract_x = calculator_atom_site.fract_x[site_index]
+        fract_y = calculator_atom_site.fract_y[site_index]
+        fract_z = calculator_atom_site.fract_z[site_index]
 
         # Atom site occupancy
-        occupancy = calculator_atom_site.occupancy[i]
+        occupancy = calculator_atom_site.occupancy[site_index]
 
         # Atom site ADP type
-        adp_type = calculator_atom_site.adp_type[i]
+        adp_type = calculator_atom_site.adp_type[site_index]
 
         # Atom site isotropic ADP
-        U_iso_or_equiv = calculator_atom_site.u_iso_or_equiv[i]
+        U_iso_or_equiv = calculator_atom_site.u_iso_or_equiv[site_index]
 
         # Atom site anisotropic ADP
         adp = None
         if calculator_phase.atom_site_aniso is not None:
-            if i < len(calculator_phase.atom_site_aniso.u_11):
+            if site_index < len(calculator_phase.atom_site_aniso.u_11):
                 mapping_adp = mapping_phase + '.atom_site_aniso'
 
-                adp = [calculator_phase.atom_site_aniso.u_11[i],
-                       calculator_phase.atom_site_aniso.u_22[i],
-                       calculator_phase.atom_site_aniso.u_33[i],
-                       calculator_phase.atom_site_aniso.u_12[i],
-                       calculator_phase.atom_site_aniso.u_13[i],
-                       calculator_phase.atom_site_aniso.u_23[i]]
+                adp = [calculator_phase.atom_site_aniso.u_11[site_index],
+                       calculator_phase.atom_site_aniso.u_22[site_index],
+                       calculator_phase.atom_site_aniso.u_33[site_index],
+                       calculator_phase.atom_site_aniso.u_12[site_index],
+                       calculator_phase.atom_site_aniso.u_13[site_index],
+                       calculator_phase.atom_site_aniso.u_23[site_index]]
                 adp = self._createProjItemFromObj(ADP.fromPars,
                                                   ['u_11', 'u_22', 'u_33',
                                                    'u_12', 'u_13', 'u_23'],
                                                   adp)
-                adp['u_11']['mapping'] = mapping_adp + '.u_11[{}]'.format(i)
-                adp['u_22']['mapping'] = mapping_adp + '.u_22[{}]'.format(i)
-                adp['u_33']['mapping'] = mapping_adp + '.u_33[{}]'.format(i)
-                adp['u_12']['mapping'] = mapping_adp + '.u_12[{}]'.format(i)
-                adp['u_13']['mapping'] = mapping_adp + '.u_13[{}]'.format(i)
-                adp['u_23']['mapping'] = mapping_adp + '.u_23[{}]'.format(i)
+                adp['u_11']['mapping'] = mapping_adp + '.u_11[{}]'.format(site_index)
+                adp['u_22']['mapping'] = mapping_adp + '.u_22[{}]'.format(site_index)
+                adp['u_33']['mapping'] = mapping_adp + '.u_33[{}]'.format(site_index)
+                adp['u_12']['mapping'] = mapping_adp + '.u_12[{}]'.format(site_index)
+                adp['u_13']['mapping'] = mapping_adp + '.u_13[{}]'.format(site_index)
+                adp['u_23']['mapping'] = mapping_adp + '.u_23[{}]'.format(site_index)
 
         # Atom site MSP
         msp = None
         if calculator_phase.atom_site_susceptibility is not None:
-            if i < len(calculator_phase.atom_site_susceptibility.chi_type):
+            if site_index < len(calculator_phase.atom_site_susceptibility.chi_type):
                 mapping_msp = mapping_phase + '.atom_site_susceptibility'
 
-                msp = [calculator_phase.atom_site_susceptibility.chi_type[i],
-                       calculator_phase.atom_site_susceptibility.chi_11[i],
-                       calculator_phase.atom_site_susceptibility.chi_22[i],
-                       calculator_phase.atom_site_susceptibility.chi_33[i],
-                       calculator_phase.atom_site_susceptibility.chi_12[i],
-                       calculator_phase.atom_site_susceptibility.chi_13[i],
-                       calculator_phase.atom_site_susceptibility.chi_23[i]]
+                msp = [calculator_phase.atom_site_susceptibility.chi_type[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_11[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_22[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_33[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_12[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_13[site_index],
+                       calculator_phase.atom_site_susceptibility.chi_23[site_index]]
                 msp = self._createProjItemFromObj(MSP.fromPars,
                                                   ['MSPtype', 'chi_11', 'chi_22', 'chi_33',
                                                    'chi_12', 'chi_13', 'chi_23'],
                                                   msp)
-                msp['type']['mapping'] = mapping_msp + '.chi_type[{}]'.format(i)
-                msp['chi_11']['mapping'] = mapping_msp + '.chi_11[{}]'.format(i)
-                msp['chi_22']['mapping'] = mapping_msp + '.chi_22[{}]'.format(i)
-                msp['chi_33']['mapping'] = mapping_msp + '.chi_33[{}]'.format(i)
-                msp['chi_12']['mapping'] = mapping_msp + '.chi_12[{}]'.format(i)
-                msp['chi_13']['mapping'] = mapping_msp + '.chi_13[{}]'.format(i)
-                msp['chi_23']['mapping'] = mapping_msp + '.chi_23[{}]'.format(i)
+                msp['type']['mapping'] = mapping_msp + '.chi_type[{}]'.format(site_index)
+                msp['chi_11']['mapping'] = mapping_msp + '.chi_11[{}]'.format(site_index)
+                msp['chi_22']['mapping'] = mapping_msp + '.chi_22[{}]'.format(site_index)
+                msp['chi_33']['mapping'] = mapping_msp + '.chi_33[{}]'.format(site_index)
+                msp['chi_12']['mapping'] = mapping_msp + '.chi_12[{}]'.format(site_index)
+                msp['chi_13']['mapping'] = mapping_msp + '.chi_13[{}]'.format(site_index)
+                msp['chi_23']['mapping'] = mapping_msp + '.chi_23[{}]'.format(site_index)
 
         # Add an atom to atoms
         atom = self._createProjItemFromObj(
@@ -551,13 +611,13 @@ class CryspyCalculator:
              fract_x, fract_y, fract_z, occupancy, adp_type,
              U_iso_or_equiv, adp, msp])
 
-        atom['scat_length_neutron']['mapping'] = mapping_atom + '.scat_length_neutron[{}]'.format(i)
-        atom['fract_x']['mapping'] = mapping_atom + '.fract_x[{}]'.format(i)
-        atom['fract_y']['mapping'] = mapping_atom + '.fract_y[{}]'.format(i)
-        atom['fract_z']['mapping'] = mapping_atom + '.fract_z[{}]'.format(i)
-        atom['occupancy']['mapping'] = mapping_atom + '.occupancy[{}]'.format(i)
-        atom['adp_type']['mapping'] = mapping_atom + '.adp_type[{}]'.format(i)
-        atom['U_iso_or_equiv']['mapping'] = mapping_atom + '.u_iso_or_equiv[{}]'.format(i)
+        atom['scat_length_neutron']['mapping'] = mapping_atom + '.scat_length_neutron[{}]'.format(site_index)
+        atom['fract_x']['mapping'] = mapping_atom + '.fract_x[{}]'.format(site_index)
+        atom['fract_y']['mapping'] = mapping_atom + '.fract_y[{}]'.format(site_index)
+        atom['fract_z']['mapping'] = mapping_atom + '.fract_z[{}]'.format(site_index)
+        atom['occupancy']['mapping'] = mapping_atom + '.occupancy[{}]'.format(site_index)
+        atom['adp_type']['mapping'] = mapping_atom + '.adp_type[{}]'.format(site_index)
+        atom['U_iso_or_equiv']['mapping'] = mapping_atom + '.u_iso_or_equiv[{}]'.format(site_index)
         return atom
 
     @staticmethod
@@ -597,9 +657,9 @@ class CryspyCalculator:
         phase.setItemByPath(['sites', 'fract_z'], atom_site_list[2])
         phase.setItemByPath(['sites', 'scat_length_neutron'], atom_site_list[3])
 
-    def _getPhasesSpace_group(self, phase_name: str) -> SpaceGroup:
+    def _getPhasesSpaceGroup(self, phase_name: str) -> SpaceGroup:
         mapping_base = 'self._cryspy_obj.crystals'
-        i = self._phase_name.index(phase_name)
+        i = self._phase_names.index(phase_name)
         calculator_phase = self._cryspy_obj.crystals[i]
         # logging.info(calculator_phase_name)
         mapping_phase = mapping_base + '[{}]'.format(i)
@@ -620,7 +680,7 @@ class CryspyCalculator:
 
     def _getPhaseCell(self, phase_name: str) -> Cell:
         mapping_base = 'self._cryspy_obj.crystals'
-        i = self._phase_name.index(phase_name)
+        i = self._phase_names.index(phase_name)
         calculator_phase = self._cryspy_obj.crystals[i]
         # logging.info(calculator_phase_name)
         mapping_phase = mapping_base + '[{}]'.format(i)
@@ -641,6 +701,9 @@ class CryspyCalculator:
 
     @time_it
     def getExperiments(self) -> Experiments:
+        """
+        Returns all experiments from the calculator object.
+        """
         experiments = []
 
         mapping_base = 'self._cryspy_obj.experiments'
@@ -717,13 +780,12 @@ class CryspyCalculator:
                                                       backgrounds, resolution, data])
 
             # Fix up phase scale, but it is a terrible way of doing things.....
-            experiment['phase'][calculator_experiment.phase.label[0]] = experiment['phase'][calculator_experiment_name]
-            experiment['phase'][calculator_experiment.phase.label[0]]['scale'].refine = scale[0].refinement
-            experiment['phase'][calculator_experiment.phase.label[0]]['scale']['store']['hide'] = scale[
-                0].constraint_flag
-            experiment['phase'][calculator_experiment.phase.label[0]]['name'] = calculator_experiment.phase.label[0]
-            experiment['phase'][calculator_experiment.phase.label[0]]['scale'][
-                'mapping'] = mapping_exp + '.phase.scale[0]'
+            phase_label = calculator_experiment.phase.label[0]
+            experiment['phase'][phase_label] = experiment['phase'][calculator_experiment_name]
+            experiment['phase'][phase_label]['scale'].refine = scale[0].refinement
+            experiment['phase'][phase_label]['scale']['store']['hide'] = scale[0].constraint_flag
+            experiment['phase'][phase_label]['name'] = phase_label
+            experiment['phase'][phase_label]['scale']['mapping'] = mapping_exp + '.phase.scale[0]'
             del experiment['phase'][calculator_experiment_name]
             if len(scale) > 1:
                 for idx, item in enumerate(calculator_experiment.phase.item[1:]):
@@ -743,6 +805,9 @@ class CryspyCalculator:
         return Experiments(experiments)
 
     def getCalculations(self) -> Calculations:
+        """
+        Returns all calculations from the calculator object.
+        """
         if not isinstance(self._cryspy_obj, cryspy.scripts.cl_rhochi.RhoChi) or self._cryspy_obj.experiments is None:
             return Calculations({})
         self._cryspy_obj.apply_constraint()
@@ -915,7 +980,7 @@ class CryspyCalculator:
         return name
 
     def getPhaseNames(self) -> list:
-        return self._phase_name
+        return self._phase_names
 
     @time_it
     def addPhase(self, phase: Phase) -> NoReturn:
@@ -924,7 +989,7 @@ class CryspyCalculator:
             self._cryspy_obj.crystals = [phase_obj, *self._cryspy_obj.crystals]
         else:
             self._cryspy_obj.crystals = [phase_obj]
-        self._phase_name = [phase.data_name for phase in self._cryspy_obj.crystals]
+        self._phase_names = [phase.data_name for phase in self._cryspy_obj.crystals]
         self._cryspy_obj.apply_constraint()
 
     @time_it
@@ -934,16 +999,16 @@ class CryspyCalculator:
             self._cryspy_obj.experiments = [exp_obj, *self._cryspy_obj.experiments]
         else:
             self._cryspy_obj.experiments = [exp_obj]
-        self._experiment_name = [experiment.data_name for experiment in self._cryspy_obj.experiments]
+        self._experiment_names = [experiment.data_name for experiment in self._cryspy_obj.experiments]
 
     @staticmethod
     def _createPhaseObj(phase: Phase) -> Crystal:
-        this_cell = cpCell(length_a=phase['cell']['length_a'].value,
-                           length_b=phase['cell']['length_b'].value,
-                           length_c=phase['cell']['length_c'].value,
-                           angle_alpha=phase['cell']['angle_alpha'].value,
-                           angle_beta=phase['cell']['angle_beta'].value,
-                           angle_gamma=phase['cell']['angle_gamma'].value)
+        this_cell = cryspyCell(length_a=phase['cell']['length_a'].value,
+                               length_b=phase['cell']['length_b'].value,
+                               length_c=phase['cell']['length_c'].value,
+                               angle_alpha=phase['cell']['angle_alpha'].value,
+                               angle_beta=phase['cell']['angle_beta'].value,
+                               angle_gamma=phase['cell']['angle_gamma'].value)
 
         this_space_group = cpSpaceGroup(name_hm_alt=phase['spacegroup']['space_group_name_HM_alt'].value,
                                         it_number=phase['spacegroup']['space_group_IT_number'].value,
@@ -1033,7 +1098,7 @@ class CryspyCalculator:
         phases = PhaseL(
             list(
                 map(
-                    lambda key: cpPhase(label=key, scale=experiment['phase'][key]['scale'].value),
+                    lambda key: cryspyPhase(label=key, scale=experiment['phase'][key]['scale'].value),
                     experiment['phase'].keys()
                 )
             )
@@ -1046,13 +1111,13 @@ class CryspyCalculator:
                   phase=phases, setup=instrument)
 
     def associatePhaseToExp(self, exp_name: str, phase_name: str, scale: float) -> NoReturn:
-        cryspyPhase = cpPhase(label=phase_name, scale=scale)
-        idx = self._experiment_name.index(exp_name)
-        self._cryspy_obj.experiments[idx].phase = PhaseL([cryspyPhase, *self._cryspy_obj.experiments[idx].phase.item])
+        cryspyPhaseObj = cryspyPhase(label=phase_name, scale=scale)
+        idx = self._experiment_names.index(exp_name)
+        self._cryspy_obj.experiments[idx].phase = PhaseL([cryspyPhaseObj, *self._cryspy_obj.experiments[idx].phase.item])
         self._log.info('Associated phase %s to experiment %s', phase_name, exp_name)
 
-    def disassociatePhaseToExp(self, exp_name: str, phase_name: str) -> NoReturn:
-        idx = self._experiment_name.index(exp_name)
+    def disassociatePhaseFromExp(self, exp_name: str, phase_name: str) -> NoReturn:
+        idx = self._experiment_names.index(exp_name)
         exp_phases = self._cryspy_obj.experiments[idx].phase
         exp_phases = PhaseL(
             [exp_phases.item[i] for i, item in enumerate(exp_phases.item) if exp_phases.items[i][0] != phase_name])
@@ -1060,7 +1125,7 @@ class CryspyCalculator:
         self._log.info('Disassociated phase %s from experiment %s', phase_name, exp_name)
 
     def getPhasesAssocatedToExp(self, exp_name: str) -> list:
-        idx = self._experiment_name.index(exp_name)
+        idx = self._experiment_names.index(exp_name)
         phases = self._cryspy_obj.experiments[idx].phase
         # THIS IS A HACK AS CRYSPY IS SGSHRGFHGHRTGYHT
         exp_phases = [item[0] for item in phases.items]

--- a/easyInterface/Diffraction/Interface.py
+++ b/easyInterface/Diffraction/Interface.py
@@ -237,7 +237,7 @@ class CalculatorInterface:
         :param phase_name: The name of the phase to be removed.
         :raises KeyError: If the exp_name or phase_name are unknown
         """
-        self.calculator.disassociatePhaseToExp(exp_name, phase_name)
+        self.calculator.disassociatePhaseFromExp(exp_name, phase_name)
         self.project_dict.rmItemByPath(['experiments', exp_name, 'phase', phase_name])
         self.__last_updated = datetime.now()
 
@@ -463,12 +463,12 @@ class CalculatorInterface:
         calculation = self.project_dict['calculations'][calculation_name]
         return calculation
 
-    def setPhase(self, phase: Union[Phase, dict]) -> NoReturn:
+    def setPhase(self, phase: Phase) -> NoReturn:
         """
         Modify a phase in the calculator. The phase will be added if it does not currently exist.
 
         :param phase: easyInterface phase object to be added.
-        :raises TypeError: If the phase object is not a easyInterface phase object or dictionary object.
+        :raises TypeError: If the phase object is not a easyInterface phase object.
         """
         if isinstance(phase, Phase):
             new_phase_name = phase['phasename']
@@ -482,7 +482,7 @@ class CalculatorInterface:
         else:
             raise TypeError
 
-    def setPhases(self, phases: Union[Phase, Phases, None] = None) -> NoReturn:
+    def setPhases(self, phases: Union[Phase, Phases]) -> NoReturn:
         """
         Set the phases in the calculator to an easyInterface phases object. If a phase in the supplied phases exists
         then the phase will be modified, if not, it will be added.
@@ -536,13 +536,13 @@ class CalculatorInterface:
         self.project_dict.setItemByPath(['phases', phase, *key, 'store', 'value'], value)
         self._mappedValueUpdater(['phases', phase, *key], value)
 
-    def setExperiment(self, experiment: Union[Experiment, dict]) -> NoReturn:
+    def setExperiment(self, experiment: Experiment) -> NoReturn:
         """
         Set an experiment to the project dictionary. If an experiment by the same name exists, the necessary changes will
         be propagated. If if does not exist, then it will be added to the project dictionary.
 
         :param experiment: Experiment container with experimental information
-        :raises TypeError: If the input isn't an `Experiment` or dictionary of an experiment.
+        :raises TypeError: If the input isn't an `Experiment`.
         """
         if isinstance(experiment, Experiment):
             new_phase_name = experiment['name']

--- a/easyInterface/Diffraction/Interface.py
+++ b/easyInterface/Diffraction/Interface.py
@@ -4,7 +4,7 @@ __version__ = "2020_02_01"
 import os
 from datetime import datetime
 from copy import deepcopy
-from typing import List, Callable, Any, Union, Optional
+from typing import List, Callable, Any, Union, Optional, NoReturn
 
 from easyInterface.Diffraction.DataClasses.DataObj.Calculation import Calculation, Calculations
 from easyInterface.Diffraction.DataClasses.DataObj.Experiment import Experiments, Experiment, ExperimentPhase
@@ -23,7 +23,7 @@ class ProjectDict(LoggedUndoableDict):
     """
 
     def __init__(self, interface: Interface, app: App, calculator: Calculator, info: Info, phases: Phases,
-                 experiments: Experiments, calculations: Calculations) -> None:
+                 experiments: Experiments, calculations: Calculations):
         """
         Create the main project dictionary from base constituent classes. Generally called from one of the constructor
         methods.
@@ -42,7 +42,7 @@ class ProjectDict(LoggedUndoableDict):
         self._log.debug('Created a project dictionary')
 
     @classmethod
-    def default(cls) -> 'LoggedUndoableDict':
+    def default(cls):
         """
         Create a default and empty project dictionary
 
@@ -60,7 +60,7 @@ class ProjectDict(LoggedUndoableDict):
     @classmethod
     def fromPars(cls, experiments: Union[Experiments, Experiment, List[Experiment]],
                  phases: Union[Phases, Phase, List[Phase]],
-                 calculations: Optional[Union[Calculations, Calculation, List[Calculation]]] = {}) -> 'LoggedUndoableDict':
+                 calculations: Optional[Union[Calculations, Calculation, List[Calculation]]] = {}):
         """
         Create a main project dictionary from phases and experiments.
 
@@ -124,7 +124,7 @@ class CalculatorInterface:
         """
         return self.calculator.final_chi_square
 
-    def setProjectFromCalculator(self):
+    def setProjectFromCalculator(self) -> NoReturn:
         """
         Sets the project dictionary from the calculator given on initialisation. Calling this function will regenerate
         the project dictionary and changes may be lost.
@@ -154,7 +154,7 @@ class CalculatorInterface:
     ###
 
     # Phase section
-    def setPhaseDefinition(self, phase_path: str):
+    def setPhaseDefinition(self, phase_path: str) -> NoReturn:
         """
         Parse a phases cif file and replace existing crystal phases
 
@@ -171,7 +171,7 @@ class CalculatorInterface:
         self.updatePhases()
         self.updateExperiments()
 
-    def addPhaseDefinition(self, phase_path: str):
+    def addPhaseDefinition(self, phase_path: str) -> NoReturn:
         """
         Add new phases from a cif file to the list of existing crystal phases in the calculator.
 
@@ -186,7 +186,7 @@ class CalculatorInterface:
         self.calculator.addPhaseDefinition(phase_path)
         self.updatePhases()
 
-    def addPhase(self, phase: Phase):
+    def addPhase(self, phase: Phase) -> NoReturn:
         """
         Add a new phase from an easyInterface phase object to the list of existing crystal phases in the calculator.
 
@@ -199,7 +199,7 @@ class CalculatorInterface:
             self.calculator.addPhase(phase)
         self.__last_updated = datetime.now()
 
-    def removePhase(self, phase_name: str):
+    def removePhase(self, phase_name: str) -> NoReturn:
         """
         Remove a phase of a given name from the dictionary and the calculator object.
 
@@ -209,7 +209,7 @@ class CalculatorInterface:
         self.project_dict.rmItemByPath(['phases', phase_name])
         self.__last_updated = datetime.now()
 
-    def addPhaseToExp(self, exp_name: str, phase_name: str, scale: float = 0.0):
+    def addPhaseToExp(self, exp_name: str, phase_name: str, scale: float = 0.0) -> NoReturn:
         """
         Link a phase in the project dictionary to an experiment in the project dictionary. Links in the calculator will
         also be made.
@@ -229,7 +229,7 @@ class CalculatorInterface:
         self.project_dict.setItemByPath(['experiments', exp_name, 'phase'], currentPhases)
         self.__last_updated = datetime.now()
 
-    def removePhaseFromExp(self, exp_name: str, phase_name: str):
+    def removePhaseFromExp(self, exp_name: str, phase_name: str) -> NoReturn:
         """
         Remove the link between an experiment and a crystallographic phase. Links in the calculator will also be removed.
 
@@ -242,7 +242,7 @@ class CalculatorInterface:
         self.__last_updated = datetime.now()
 
     # Experiment section
-    def setExperimentDefinition(self, exp_path: str):
+    def setExperimentDefinition(self, exp_path: str) -> NoReturn:
         """
         Set an experiment/s to be simulated from a cif file. Note that this will not have any crystallographic phases
         associated with it.
@@ -253,7 +253,7 @@ class CalculatorInterface:
         # This will re-create all local directories
         self.updateExperiments()
 
-    def addExperimentDefinition(self, exp_path: str):
+    def addExperimentDefinition(self, exp_path: str) -> NoReturn:
         """
         Add an experiment to be simulated from a cif file. Note that this will not have any crystallographic phases
         associated with it.
@@ -263,7 +263,7 @@ class CalculatorInterface:
         self.calculator.addExpsDefinition(exp_path)
         self.updateExperiments()
 
-    def addExperiment(self, experiment: Experiment):
+    def addExperiment(self, experiment: Experiment) -> NoReturn:
         """
         Add an experiment to the list of experiments in both the project dict and the calculator.
 
@@ -276,7 +276,7 @@ class CalculatorInterface:
             self.calculator.setExperiments(self.project_dict['experiments'])
         self.__last_updated = datetime.now()
 
-    def removeExperiment(self, experiment_name: str):
+    def removeExperiment(self, experiment_name: str) -> NoReturn:
         """
         Remove a experiment from both the project dictionary and the calculator.
 
@@ -287,7 +287,7 @@ class CalculatorInterface:
         self.__last_updated = datetime.now()
 
     # Output section
-    def writeMainCif(self, save_dir: str):
+    def writeMainCif(self, save_dir: str) -> NoReturn:
         """
         Write the `main.cif` where links to the experiments and phases are stored and other generalised project
         information.
@@ -296,7 +296,7 @@ class CalculatorInterface:
         """
         self.calculator.writeMainCif(save_dir)
 
-    def writePhaseCif(self, save_dir: str):
+    def writePhaseCif(self, save_dir: str) -> NoReturn:
         """
         Write the `phases.cif` where all phases in the project dictionary are saved to file. This cif file should be
         compatible with other crystallographic software.
@@ -305,7 +305,7 @@ class CalculatorInterface:
         """
         self.calculator.writePhaseCif(save_dir)
 
-    def writeExpCif(self, save_dir: str):
+    def writeExpCif(self, save_dir: str) -> NoReturn:
         """
         Write the `experiments.cif` where all experiments in the project dictionary are saved to file. This includes the
         instrumental parameters and which phases are in the experiment/s
@@ -314,7 +314,7 @@ class CalculatorInterface:
         """
         self.calculator.writeExpCif(save_dir)
 
-    def saveCifs(self, save_dir: str):
+    def saveCifs(self, save_dir: str) -> NoReturn:
         """
         Write project cif files (`main.cif`, `experiments.cif` and `phases.cif`) to a user supplied directory. This
         contains all information needed to recreate the project dictionary.
@@ -329,7 +329,7 @@ class CalculatorInterface:
     # Syncing between Calculator/Dict
     ###
     @time_it
-    def updatePhases(self):
+    def updatePhases(self) -> NoReturn:
         """
         Synchronise the phases in project dictionary by queering the calculator object.
         """
@@ -374,7 +374,7 @@ class CalculatorInterface:
             raise KeyError
 
     @time_it
-    def updateExperiments(self):
+    def updateExperiments(self) -> NoReturn:
         """
         Synchronise the experiments portion of the project dictionary from the calculator.
         """
@@ -419,7 +419,7 @@ class CalculatorInterface:
             raise KeyError
 
     @time_it
-    def updateCalculations(self):
+    def updateCalculations(self) -> NoReturn:
         """
         Calculate all experiments and populate the calculations field in the project dictionary. Note that this will
         only occur if a member of the phases or experiments section of the project dictionary has been modified since
@@ -452,7 +452,7 @@ class CalculatorInterface:
         calculation = self.project_dict['calculations'][calculation_name]
         return calculation
 
-    def setPhase(self, phase: Union[Phase, dict]):
+    def setPhase(self, phase: Union[Phase, dict]) -> NoReturn:
         """
         Modify a phase in the calculator. The phase will be added if it does not currently exist.
 
@@ -471,7 +471,7 @@ class CalculatorInterface:
         else:
             raise TypeError
 
-    def setPhases(self, phases: Union[Phase, Phases, None] = None):
+    def setPhases(self, phases: Union[Phase, Phases, None] = None) -> NoReturn:
         """
         Set the phases in the calculator to an easyInterface phases object. If a phase in the supplied phases exists
         then the phase will be modified, if not, it will be added.
@@ -491,7 +491,16 @@ class CalculatorInterface:
         self._mappedBulkUpdate(self._mappedValueUpdater, k, v)
         self.__last_updated = datetime.now()
 
-    def setPhaseRefine(self, phase: str, key: List[str], value: bool = True):
+    def setPhaseRefine(self, phase: str, key: List[str], value: bool = True) -> NoReturn:
+        """
+        Shortcut for setting the refinement key for items in the phase list.
+
+        :param phase: Name of phase to be modified
+        :param key: Location of element to be modified in the named phase.
+        :param value: Should the parameter specified by above be refined
+
+        :raises KeyError: If phase is unknown
+        """
         if phase not in self.project_dict['phases'].keys():
             raise KeyError
         if key[-2:] == ['store', 'value']:
@@ -499,7 +508,16 @@ class CalculatorInterface:
         self.project_dict.setItemByPath(['phases', phase, *key, 'store', 'refine'], value)
         self._mappedRefineUpdater(['phases', phase, *key], value)
 
-    def setPhaseValue(self, phase: str, key: List[str], value):
+    def setPhaseValue(self, phase: str, key: List[str], value) -> NoReturn:
+        """
+        Shortcut for setting the value key for items in the phase list.
+
+        :param phase: Name of phase to be modified
+        :param key: Location of element to be modified in the named phase.
+        :param value: New value of the parameter specified by above
+
+        :raises KeyError: If phase is unknown
+        """
         if phase not in self.project_dict['phases'].keys():
             raise KeyError
         if key[-2:] == ['store', 'value']:
@@ -507,8 +525,14 @@ class CalculatorInterface:
         self.project_dict.setItemByPath(['phases', phase, *key, 'store', 'value'], value)
         self._mappedValueUpdater(['phases', phase, *key], value)
 
-    def setExperiment(self, experiment: Union[Experiment, dict]):
-        """Set phases (sample model tab in GUI)"""
+    def setExperiment(self, experiment: Union[Experiment, dict]) -> NoReturn:
+        """
+        Set an experiment to the project dictionary. If an experiment by the same name exists, the necessary changes will
+        be propagated. If if does not exist, then it will be added to the project dictionary.
+
+        :param experiment: Experiment container with experimental information
+        :raises TypeError: If the input isn't an `Experiment` or dictionary of an experiment.
+        """
         if isinstance(experiment, Experiment):
             new_phase_name = experiment['name']
             if new_phase_name in self.project_dict['experiments'].keys():
@@ -521,8 +545,13 @@ class CalculatorInterface:
             raise TypeError
         self.__last_updated = datetime.now()
 
-    def setExperiments(self, experiments: Union[Experiment, Experiments, dict]):
-        """Set experiments (Experimental data tab in GUI)"""
+    def setExperiments(self, experiments: Union[Experiment, Experiments]):
+        """
+        Overwrite all experiments in the project dictionary with supplied experiments.
+
+        :param experiments: Experiments container with experimental information
+        :raises TypeError: If the input isn't an `Experiments` or `Experiment.
+        """
         if isinstance(experiments, Experiment):
             new_exp_name = experiments['name']
             self.project_dict.setItemByPath(['experiments', new_exp_name], experiments)
@@ -530,10 +559,21 @@ class CalculatorInterface:
             self.project_dict.bulkUpdate([['experiments', item] for item in list(experiments.keys())],
                                          [experiments[key] for key in experiments.keys()],
                                          "Setting new experiments")
+        else:
+            raise TypeError
         self.calculator.setExperiments(self.project_dict['experiments'])
         self.__last_updated = datetime.now()
 
-    def setExperimentRefine(self, experiment: str, key: List[str], value: bool = True):
+    def setExperimentRefine(self, experiment: str, key: List[str], value: bool = True) -> NoReturn:
+        """
+        Shortcut for setting the refinement key for items in the experiment list.
+
+        :param experiment: Name of experiment to be modified
+        :param key: Location of element to be modified in the named experiment.
+        :param value: Should the parameter specified by above be refined
+
+        :raises KeyError: If experiment is unknown
+        """
         if experiment not in self.project_dict['experiments'].keys():
             raise KeyError
         if key[-2:] == ['store', 'value']:
@@ -542,6 +582,15 @@ class CalculatorInterface:
         self._mappedRefineUpdater(['experiments', experiment, *key], value)
 
     def setExperimentValue(self, experiment: str, key: List[str], value):
+        """
+        Shortcut for setting the value key for items in the experiment list.
+
+        :param experiment: Name of experiment to be modified
+        :param key: Location of element to be modified in the named experiment.
+        :param value: New value of the parameter specified by above
+
+        :raises KeyError: If experiment is unknown
+        """
         if experiment not in self.project_dict['experiments'].keys():
             raise KeyError
         if key[-2:] == ['store', 'value']:
@@ -549,7 +598,7 @@ class CalculatorInterface:
         self.project_dict.setItemByPath(['experiments', experiment, *key, 'store', 'value'], value)
         self._mappedValueUpdater(['experiments', experiment, *key], value)
 
-    def setCalculatorFromProject(self) -> None:
+    def setCalculatorFromProject(self) -> NoReturn:
         """
         Resets the project phases and experiments fields of the project dictionary from the calculator.
         """
@@ -561,12 +610,13 @@ class CalculatorInterface:
         Returns an object in the project dictionary by the path to the object.
 
         :param keys: Path to the object in the project dictionary
-        :raises KeyError: The supplied keys do not return an object in the project dictionary
         :return: Object from the project dictionary.
+
+        :raises KeyError: The supplied keys do not return an object in the project dictionary
         """
         return self.project_dict.getItemByPath(keys)
 
-    def setDictByPath(self, keys: List[str], value: Any) -> None:
+    def setDictByPath(self, keys: List[str], value: Any) -> NoReturn:
         """
         Set an object in the project dictionary by a key path.
 
@@ -583,19 +633,25 @@ class CalculatorInterface:
 
     def phasesCount(self) -> int:
         """
-        Returns number of phases in the project dictionary.
+        Get the number of phases in the project dictionary.
+
+        :return: number of phases in the project dictionary.
         """
         return len(self.project_dict['phases'])
 
     def experimentsCount(self) -> int:
         """
-        Returns number of experiments in the project dictionary.
+        Get the number of experiments in the project dictionary.
+
+        :return: number of experiments in the project dictionary.
         """
         return len(self.project_dict['experiments'])
 
     def phasesIds(self) -> List[str]:
         """
-        Returns labels of the phases in the project dictionary.
+        Get the labels of the phases in the project dictionary.
+
+        :return: labels of the phases in the project dictionary.
         """
         return list(self.project_dict['phases'].keys())
 
@@ -694,7 +750,7 @@ class CalculatorInterface:
         """
         return self.project_dict.canRedo()
 
-    def clearUndoStack(self):
+    def clearUndoStack(self) -> NoReturn:
         """
         Resets the Undo/Redo stack of the project dictionary.
 
@@ -702,13 +758,13 @@ class CalculatorInterface:
         """
         self.project_dict.clearUndoStack()
 
-    def undo(self):
+    def undo(self) -> NoReturn:
         """
         Perform an undo operation on the project dictionary.
         """
         self.project_dict.undo()
 
-    def redo(self):
+    def redo(self) -> NoReturn:
         """
         Perform an redo operation on the project dictionary.
         """
@@ -718,7 +774,14 @@ class CalculatorInterface:
     # Hidden internal logic
     ###
 
-    def _mappedBulkUpdate(self, func: Callable, keys: list, values: list):
+    def _mappedBulkUpdate(self, func: Callable, keys: List[List], values: List[Any]) -> NoReturn:
+        """
+        Perform a bulk update on the project dictionary
+
+        :param func: An updater function which can take key (list) and value pairs and update the project dictionary
+        :param keys: List of update keys, each consisting of a list representing an update key
+        :param values: List of values to be set.
+        """
         self.project_dict.bulkUpdate(keys, values, 'Updating Dictionary')
         for k, v in zip(keys, values):
             if k[-2:] == ['store', 'value']:
@@ -727,13 +790,24 @@ class CalculatorInterface:
         self.__last_updated = datetime.now()
         self.updateCalculations()
 
-    def _mappedValueUpdater(self, key, value):
+    def _mappedValueUpdater(self, key: list, value: Any) -> NoReturn:
+        """
+        Updater function for `_mappedBulkUpdate`. This function modifies values
+
+        :param key: Location of update
+        :param value: Update value
+        """
         update_str = self.project_dict.getItemByPath(key)['mapping']
         self.calculator._mappedValueUpdater(update_str, value)
         self.__last_updated = datetime.now()
 
-    def _mappedRefineUpdater(self, key, value):
+    def _mappedRefineUpdater(self, key: list, value: bool) -> NoReturn:
+        """
+        Updater function for `_mappedBulkUpdate`. This function modifies refinement
+
+        :param key: Location of update
+        :param value: Update value
+        """
         update_str = self.project_dict.getItemByPath(key)['mapping']
         self.calculator._mappedRefineUpdater(update_str, value)
-
 

--- a/easyInterface/Diffraction/Interface.py
+++ b/easyInterface/Diffraction/Interface.py
@@ -1,5 +1,5 @@
 __author__ = 'simonward'
-__version__ = "2020_02_01"
+__version__ = "2020_03_09"
 
 import os
 from datetime import datetime
@@ -250,6 +250,17 @@ class CalculatorInterface:
         :param exp_path: Path to a experiment file (`.cif`)
         """
         self.calculator.setExpsDefinition(exp_path)
+        # This will re-create all local directories
+        self.updateExperiments()
+
+    def setExperimentDefinitionFromString(self, exp_cif_string: str) -> NoReturn:
+        """
+        Set an experiment/s to be simulated from a string. Note that this will not have any crystallographic phases
+        associated with it.
+
+        :param exp_cif_string: String containing the contents of an experiment file (`.cif`)
+        """
+        self.calculator.addExpDefinitionFromString(exp_cif_string)
         # This will re-create all local directories
         self.updateExperiments()
 
@@ -797,8 +808,22 @@ class CalculatorInterface:
         :param key: Location of update
         :param value: Update value
         """
-        update_str = self.project_dict.getItemByPath(key)['mapping']
-        self.calculator._mappedValueUpdater(update_str, value)
+
+        def code_error(keys):
+            if keys[0] == 'phases':
+                self.updatePhases()
+            else:
+                self.updateExperiments()
+            self.setCalculatorFromProject()
+            self.__last_updated = datetime.now()
+        try:
+            update_str = self.project_dict.getItemByPath(key)['mapping']
+            try:
+                self.calculator._mappedValueUpdater(update_str, value)
+            except TypeError:
+                code_error(key)
+        except (KeyError, TypeError):
+            code_error(key)
         self.__last_updated = datetime.now()
 
     def _mappedRefineUpdater(self, key: list, value: bool) -> NoReturn:
@@ -808,6 +833,19 @@ class CalculatorInterface:
         :param key: Location of update
         :param value: Update value
         """
-        update_str = self.project_dict.getItemByPath(key)['mapping']
-        self.calculator._mappedRefineUpdater(update_str, value)
 
+        def code_error(keys):
+            if keys[0] == 'phases':
+                self.updatePhases()
+            else:
+                self.updateExperiments()
+            self.setCalculatorFromProject()
+            self.__last_updated = datetime.now()
+        try:
+            update_str = self.project_dict.getItemByPath(key)['mapping']
+            try:
+                self.calculator._mappedRefineUpdater(update_str, value)
+            except TypeError:
+                code_error(key)
+        except (KeyError, TypeError):
+            code_error(key)

--- a/easyInterface/Diffraction/Interface.py
+++ b/easyInterface/Diffraction/Interface.py
@@ -23,7 +23,7 @@ class ProjectDict(LoggedUndoableDict):
     """
 
     def __init__(self, interface: Interface, app: App, calculator: Calculator, info: Info, phases: Phases,
-                 experiments: Experiments, calculations: Calculations):
+                 experiments: Experiments, calculations: Calculations) -> None:
         """
         Create the main project dictionary from base constituent classes. Generally called from one of the constructor
         methods.
@@ -42,7 +42,7 @@ class ProjectDict(LoggedUndoableDict):
         self._log.debug('Created a project dictionary')
 
     @classmethod
-    def default(cls):
+    def default(cls) -> 'ProjectDict':
         """
         Create a default and empty project dictionary
 
@@ -60,7 +60,7 @@ class ProjectDict(LoggedUndoableDict):
     @classmethod
     def fromPars(cls, experiments: Union[Experiments, Experiment, List[Experiment]],
                  phases: Union[Phases, Phase, List[Phase]],
-                 calculations: Optional[Union[Calculations, Calculation, List[Calculation]]] = {}):
+                 calculations: Optional[Union[Calculations, Calculation, List[Calculation]]] = {}) -> 'ProjectDict':
         """
         Create a main project dictionary from phases and experiments.
 
@@ -89,7 +89,7 @@ class CalculatorInterface:
     Interface to calculators in the `easyInterface.Diffraction.Calculator` class.
     """
 
-    def __init__(self, calculator: 'easyInterface.Diffraction.Calculator'):
+    def __init__(self, calculator: 'easyInterface.Diffraction.Calculator') -> None:
         """
         Initialise an interface with a `calculator` of the `easyInterface.Diffraction.Calculator` class.
 

--- a/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
+++ b/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
@@ -60,6 +60,14 @@ def test__create_cryspy_obj(cal):
 def test__parse_segment(cal):
     assert True
 
+def test_addExpDefinitionFromString(cal):
+    file = os.path.join(test_data, 'experiments.cif')
+
+    with open(file, 'r') as file_reader:
+        exp_str = file_reader.read()
+    cal.addExpDefinitionFromString(exp_str)
+    assert len(cal._cryspy_obj.experiments) == 2
+
 
 def test_set_exps_definition(cal):
     file = os.path.join(test_data, 'experiments.cif')

--- a/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
+++ b/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
@@ -300,6 +300,7 @@ def test_add_phase(cal):
     cal.setPhases(phases)
     assert len(phases) == 2
 
+
 def test_cif_writers(cal):
 
     def file_tester(path: str, option=None):
@@ -311,29 +312,26 @@ def test_cif_writers(cal):
             assert os.path.exists(os.path.join(path, 'main.cif'))
             with open(os.path.join(path, 'main.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('_name Fe3O4') is not -1
-                assert new_data.find('_phases phases.cif') is not -1
-                assert new_data.find('_experiments experiments.cif') is not -1
+                assert new_data.find('_name Fe3O4') != -1
+                assert new_data.find('_phases phases.cif') != -1
+                assert new_data.find('_experiments experiments.cif') != -1
         elif'phases' in option:
             assert os.path.exists(os.path.join(path, 'phases.cif'))
             with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('\ndata_Fe3O4') is not -1
-                assert new_data.find('\n_cell_length_b 8.36212') is not -1
-                assert new_data.find('\nFe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') is not -1
-                assert new_data.find('\nFe3A 2.0 1.0 ') is not -1
-                assert new_data.find('\nFe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') is not -1
+                print(new_data)
+                assert new_data.find('data_Fe3O4') != -1
+                assert new_data.find('_cell_length_b 8.36212') != -1
+                assert new_data.find('Fe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') != -1
+                assert new_data.find('Fe3A 2.0 1.0 ') != -1
+                assert new_data.find('Fe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') != -1
         elif 'experiments' in option:
             assert os.path.exists(os.path.join(path, 'experiments.cif'))
             with open(os.path.join(path, 'experiments.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('\ndata_pd') is not -1
-                assert new_data.find('\n_setup_offset_2theta -0.385404') is not -1
-                assert new_data.find('\n5.0 166.47 106.51 426.73 109.08') is not -1
-
-    with tempfile.TemporaryDirectory() as td:
-        cal.saveCifs(td)
-        file_tester(td)
+                assert new_data.find('data_pd') != -1
+                assert new_data.find('_setup_offset_2theta -0.385404') != -1
+                assert new_data.find('5.0 166.47 106.51 426.73 109.08') != -1
 
     with tempfile.TemporaryDirectory() as td:
         cal.writeMainCif(td)

--- a/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
+++ b/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
@@ -319,12 +319,11 @@ def test_cif_writers(cal):
             assert os.path.exists(os.path.join(path, 'phases.cif'))
             with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                print(new_data)
                 assert new_data.find('data_Fe3O4') != -1
-                assert new_data.find('_cell_length_b 8.36212') != -1
-                assert new_data.find('Fe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') != -1
+                assert new_data.find('_cell_length_b 8.56212') != -1
+                assert new_data.find('Fe3B Cani 3.041 3.041 3.041 0.0 0.0 0.0') != -1
                 assert new_data.find('Fe3A 2.0 1.0 ') != -1
-                assert new_data.find('Fe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') != -1
+                assert new_data.find('Fe3A Fe3+ 0.125 0.125 0.125 1.0 Uiso 0.0') != -1
         elif 'experiments' in option:
             assert os.path.exists(os.path.join(path, 'experiments.cif'))
             with open(os.path.join(path, 'experiments.cif'), 'r') as new_reader:

--- a/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
+++ b/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
@@ -40,7 +40,7 @@ def file_io_fixture():
 
 def test_creationEmptyFile():
     calc = CryspyCalculator('baah')
-    assert calc._phase_name == []
+    assert calc._phase_names == []
 
 
 def test_calculator_info():
@@ -76,20 +76,20 @@ def test_set_exps_definition(cal):
     cal.setExpsDefinition(file)
     assert len(cal._cryspy_obj.experiments) == 1
     assert cal._experiments_path == file
-    assert cal._experiment_name == ['pd']
+    assert cal._experiment_names == ['pd']
 
 
 def test_add_exps_definition(cal):
     file = os.path.join(test_data, 'experiments2.cif')
     cal.addExpsDefinition(file)
     assert len(cal._cryspy_obj.experiments) == 2
-    assert cal._experiment_name == ['pd', 'pd2']
+    assert cal._experiment_names == ['pd', 'pd2']
 
 
 def test_remove_exps_definition(cal):
     cal.removeExpsDefinition('pd')
     assert cal._cryspy_obj.experiments is None
-    assert cal._experiment_name == []
+    assert cal._experiment_names == []
 
 
 def test_set_phase_definition(cal):
@@ -99,22 +99,22 @@ def test_set_phase_definition(cal):
     NEW_PHASE_FILE = os.path.join(test_data, 'phases_2.cif')
     file_path = NEW_PHASE_FILE
     cal.setPhaseDefinition(file_path)
-    assert 'Fe2Co1O4' in cal._phase_name
+    assert 'Fe2Co1O4' in cal._phase_names
     assert len(cal._cryspy_obj.crystals) == 1
 
 
 def test_add_phase_definition(cal):
     file = os.path.join(test_data, 'phases_2.cif')
     cal.addPhaseDefinition(file)
-    assert len(cal._phase_name) == 2
+    assert len(cal._phase_names) == 2
     assert len(cal._cryspy_obj.crystals) == 2
-    assert cal._phase_name == ['Fe3O4', 'Fe2Co1O4']
+    assert cal._phase_names == ['Fe3O4', 'Fe2Co1O4']
 
 
 def test_remove_phase_definition(cal):
     cal.removePhaseDefinition('Fe3O4')
     assert cal._cryspy_obj.crystals is None
-    assert cal._phase_name == []
+    assert cal._phase_names == []
 
 
 def test_write_main_cif(cal, file_io_fixture):

--- a/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
+++ b/tests/easyInterface/Diffraction/Calculators/test_CryspyCalculator.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+
 import pytest
 
 from easyInterface import logger, logging
@@ -297,3 +299,50 @@ def test_add_phase(cal):
     phases = Phases([phases['Fe3O4'], phase])
     cal.setPhases(phases)
     assert len(phases) == 2
+
+def test_cif_writers(cal):
+
+    def file_tester(path: str, option=None):
+
+        if option is None:
+            option = ['main', 'phases', 'experiments']
+
+        if 'main' in option:
+            assert os.path.exists(os.path.join(path, 'main.cif'))
+            with open(os.path.join(path, 'main.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('_name Fe3O4') is not -1
+                assert new_data.find('_phases phases.cif') is not -1
+                assert new_data.find('_experiments experiments.cif') is not -1
+        elif'phases' in option:
+            assert os.path.exists(os.path.join(path, 'phases.cif'))
+            with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('\ndata_Fe3O4') is not -1
+                assert new_data.find('\n_cell_length_b 8.36212') is not -1
+                assert new_data.find('\nFe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') is not -1
+                assert new_data.find('\nFe3A 2.0 1.0 ') is not -1
+                assert new_data.find('\nFe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') is not -1
+        elif 'experiments' in option:
+            assert os.path.exists(os.path.join(path, 'experiments.cif'))
+            with open(os.path.join(path, 'experiments.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('\ndata_pd') is not -1
+                assert new_data.find('\n_setup_offset_2theta -0.385404') is not -1
+                assert new_data.find('\n5.0 166.47 106.51 426.73 109.08') is not -1
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.saveCifs(td)
+        file_tester(td)
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writeMainCif(td)
+        file_tester(td, option=['main'])
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writePhaseCif(td)
+        file_tester(td, option=['phases'])
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writeExpCif(td)
+        file_tester(td, option=['experiments'])

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -178,8 +178,9 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11']['header'] == 'U11'
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_22'].value is None
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max is np.Inf
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].min is -np.Inf
+    # TODO find out why -np.Inf != -np.Inf
+    # assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max is np.Inf
+    # assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].min is -np.Inf
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23']['store']['constraint'] is None
 

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -631,25 +631,26 @@ def test_cif_writers(cal):
             assert os.path.exists(os.path.join(path, 'main.cif'))
             with open(os.path.join(path, 'main.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('_name Fe3O4') is not -1
-                assert new_data.find('_phases phases.cif') is not -1
-                assert new_data.find('_experiments experiments.cif') is not -1
+                assert new_data.find('_name Fe3O4') != -1
+                assert new_data.find('_phases phases.cif') != -1
+                assert new_data.find('_experiments experiments.cif') != -1
         elif'phases' in option:
             assert os.path.exists(os.path.join(path, 'phases.cif'))
             with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('\ndata_Fe3O4') is not -1
-                assert new_data.find('\n_cell_length_b 8.36212') is not -1
-                assert new_data.find('\nFe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') is not -1
-                assert new_data.find('\nFe3A 2.0 1.0 ') is not -1
-                assert new_data.find('\nFe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') is not -1
+                print(new_data)
+                assert new_data.find('data_Fe3O4') != -1
+                assert new_data.find('_cell_length_b 8.36212') != -1
+                assert new_data.find('Fe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') != -1
+                assert new_data.find('Fe3A 2.0 1.0 ') != -1
+                assert new_data.find('Fe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') != -1
         elif 'experiments' in option:
             assert os.path.exists(os.path.join(path, 'experiments.cif'))
             with open(os.path.join(path, 'experiments.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                assert new_data.find('\ndata_pd') is not -1
-                assert new_data.find('\n_setup_offset_2theta -0.385404') is not -1
-                assert new_data.find('\n5.0 166.47 106.51 426.73 109.08') is not -1
+                assert new_data.find('data_pd') != -1
+                assert new_data.find('_setup_offset_2theta -0.385404') != -1
+                assert new_data.find('5.0 166.47 106.51 426.73 109.08') != -1
 
     with tempfile.TemporaryDirectory() as td:
         cal.writeMainCif(td)

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -112,14 +112,6 @@ def test_setPhaseValue(cal):
     cal.setPhaseValue('Fe3O4', ['cell', 'length_a'], 5)
     assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 5
 
-
-def test_setPhase(cal):
-    phase = cal.getPhase('Fe3O4')
-    cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value = 2
-    cal.setPhase(phase)
-    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 8.36212
-
-
 # def test_setPhases(cal):
 #     phase2 = cal.getPhase('Fe3O4')
 #     phase2['phasename'] = 'Fe3O4_2'
@@ -187,6 +179,7 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_22'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max is np.Inf
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].min is -np.Inf
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23']['store']['constraint'] is None
 

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -638,7 +638,6 @@ def test_cif_writers(cal):
             assert os.path.exists(os.path.join(path, 'phases.cif'))
             with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
                 new_data = new_reader.read()
-                print(new_data)
                 assert new_data.find('data_Fe3O4') != -1
                 assert new_data.find('_cell_length_b 8.36212') != -1
                 assert new_data.find('Fe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') != -1

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -94,6 +94,44 @@ def test_setInfoDict(cal):
     assert 'Fe3O4' == cal.project_dict['info']['name']
 
 
+def test_setPhase(cal):
+    phase = cal.getPhase('Fe3O4')
+    cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value = 2
+    cal.setPhase(phase)
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 8.36212
+
+
+def test_setPhaseRefine(cal):
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].refine is True
+    cal.setPhaseRefine('Fe3O4', ['cell', 'length_a'], False)
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].refine is False
+
+
+def test_setPhaseValue(cal):
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 8.36212
+    cal.setPhaseValue('Fe3O4', ['cell', 'length_a'], 5)
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 5
+
+
+def test_setPhase(cal):
+    phase = cal.getPhase('Fe3O4')
+    cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value = 2
+    cal.setPhase(phase)
+    assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 8.36212
+
+
+# def test_setPhases(cal):
+#     phase2 = cal.getPhase('Fe3O4')
+#     phase2['phasename'] = 'Fe3O4_2'
+#     cal.addPhase(phase2)
+#     phases = cal.getPhase(None)
+#     phases['Fe3O4']['cell']['length_a'].value = 5
+#     cal.setPhases(phases)
+#     assert len(cal.project_dict['phases']) == 2
+#     assert cal.project_dict['phases']['Fe3O4']['cell']['length_a'].value == 5
+#     assert cal.project_dict['phases']['Fe3O4_2']['cell']['length_a'].value == 8.36212
+
+
 def test_setPhasesDictFromCryspyObj(cal):
     # difficult test for creation of the phases dict
     cal.project_dict['phases'].clear()  # enforce
@@ -159,6 +197,90 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_23']['store'].max == 1
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['MSP']['chi_23'].value == 0.0
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['MSP']['chi_23']['store']['refine'] is False
+
+
+def test_setExperiment(cal):
+    experiment = cal.getExperiment('pd')
+    cal.project_dict['experiments']['pd']['wavelength'].value = 2
+    cal.setExperiment(experiment)
+    assert cal.project_dict['experiments']['pd']['wavelength'].value == 0.84
+
+
+def test_setExperiments(cal):
+    experiment = cal.getExperiment('pd')
+    experiments = Experiments(experiment)
+    experiemnt2 = deepcopy(experiment)
+    experiemnt2['name'] = 'pd2'
+    experiments['pd2'] = experiemnt2
+    cal.setExperiments(experiments)
+    assert len(cal.project_dict['experiments']) == 2
+    assert cal.project_dict['experiments']['pd']['wavelength'].value == 0.84
+    assert cal.project_dict['experiments']['pd2']['wavelength'].value == 0.84
+
+def test_setExperimentRefine(cal):
+    assert cal.project_dict['experiments']['pd']['wavelength'].refine is False
+    cal.setExperimentRefine('pd', ['wavelength'], True)
+    assert cal.project_dict['experiments']['pd']['wavelength'].refine is True
+
+def test_setExperimentValue(cal):
+    assert cal.project_dict['experiments']['pd']['wavelength'].value == 0.84
+    cal.setExperimentValue('pd', ['wavelength'], 5)
+    assert cal.project_dict['experiments']['pd']['wavelength'].value == 5
+
+def test_setExperimentDefinitionFromString():
+    calc = CryspyCalculator()
+    interface = CalculatorInterface(calc)
+    interface.setPhaseDefinition(phase_path)
+    with open(exp_path, 'r') as file_reader:
+        exp_content = file_reader.read()
+    interface.setExperimentDefinitionFromString(exp_content)
+
+    experiment_dict = interface.project_dict['experiments']
+
+    assert len(experiment_dict) == 1
+    assert len(experiment_dict['pd']) == 7
+    # wavelength
+    assert len(experiment_dict['pd']['wavelength']) == 5
+    assert experiment_dict['pd']['wavelength'].value == 0.84
+    assert experiment_dict['pd']['wavelength']['url'] == ''
+
+    # offset
+    assert len(experiment_dict['pd']['offset']) == 5
+    assert experiment_dict['pd']['offset'].value == -0.385404
+    assert experiment_dict['pd']['offset']['store']['error'] == 0.0
+    assert experiment_dict['pd']['offset']['store']['refine'] is False
+
+    # phase
+    assert len(experiment_dict['pd']['phase']) == 1
+    assert len(experiment_dict['pd']['phase']['Fe3O4']['scale']) == 5
+    assert experiment_dict['pd']['phase']['Fe3O4']['scale'].value == 0.02381
+    assert experiment_dict['pd']['phase']['Fe3O4']['scale']['store']['refine'] is False
+    assert experiment_dict['pd']['phase']['Fe3O4']['scale']['store']['error'] == 0.0
+
+    # background
+    assert len(experiment_dict['pd']['background']) == 3
+    assert experiment_dict['pd']['background']['4.5']['ttheta'] == 4.5
+    assert len(experiment_dict['pd']['background']['4.5']['intensity']) == 5
+    assert experiment_dict['pd']['background']['4.5']['intensity'].value == 256.0
+    assert experiment_dict['pd']['background']['80.0']['ttheta'] == 80.0
+    assert len(experiment_dict['pd']['background']['80.0']['intensity']) == 5
+    assert experiment_dict['pd']['background']['80.0']['intensity'].value == 65.0
+
+    # resolution
+    assert len(experiment_dict['pd']['resolution']) == 5
+    assert len(experiment_dict['pd']['resolution']['u']) == 5
+    assert experiment_dict['pd']['resolution']['u'].value == 16.9776
+    assert experiment_dict['pd']['resolution']['u']['store']['refine'] is False
+    assert len(experiment_dict['pd']['resolution']['y']) == 5
+    assert experiment_dict['pd']['resolution']['v'].value == -2.8357
+    assert experiment_dict['pd']['resolution']['v']['store']['error'] == 0.0
+    assert experiment_dict['pd']['resolution']['v']['store']['hide'] is False
+
+    # measured_pattern
+    assert len(experiment_dict['pd']['measured_pattern']) == 7
+    assert 5.0 in experiment_dict['pd']['measured_pattern']['x']
+    assert len(experiment_dict['pd']['measured_pattern'].y_obs_lower) == 381
+    assert experiment_dict['pd']['measured_pattern'].y_obs_lower[380] == pytest.approx(762.959046)
 
 
 def test_setExperimentsDictFromCryspyObj(cal):

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 
 import numpy as np
 import pytest
@@ -617,3 +618,47 @@ def test_getExperiment_None(cal):
     assert 'Testing' in exps.keys()
     assert exps['Testing']['name'] == 'Testing'
     assert exps['pd']['name'] == 'pd'
+
+
+def test_cif_writers(cal):
+
+    def file_tester(path: str, option=None):
+
+        if option is None:
+            option = ['main', 'phases', 'experiments']
+
+        if 'main' in option:
+            assert os.path.exists(os.path.join(path, 'main.cif'))
+            with open(os.path.join(path, 'main.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('_name Fe3O4') is not -1
+                assert new_data.find('_phases phases.cif') is not -1
+                assert new_data.find('_experiments experiments.cif') is not -1
+        elif'phases' in option:
+            assert os.path.exists(os.path.join(path, 'phases.cif'))
+            with open(os.path.join(path, 'phases.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('\ndata_Fe3O4') is not -1
+                assert new_data.find('\n_cell_length_b 8.36212') is not -1
+                assert new_data.find('\nFe3B Fe3+ 0.5 0.5 0.5 1.0 Uiso d 0.0 16 ') is not -1
+                assert new_data.find('\nFe3A 2.0 1.0 ') is not -1
+                assert new_data.find('\nFe3A Cani -3.468 -3.468 -3.468 0.0 0.0 0.0') is not -1
+        elif 'experiments' in option:
+            assert os.path.exists(os.path.join(path, 'experiments.cif'))
+            with open(os.path.join(path, 'experiments.cif'), 'r') as new_reader:
+                new_data = new_reader.read()
+                assert new_data.find('\ndata_pd') is not -1
+                assert new_data.find('\n_setup_offset_2theta -0.385404') is not -1
+                assert new_data.find('\n5.0 166.47 106.51 426.73 109.08') is not -1
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writeMainCif(td)
+        file_tester(td, option=['main'])
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writePhaseCif(td)
+        file_tester(td, option=['phases'])
+
+    with tempfile.TemporaryDirectory() as td:
+        cal.writeExpCif(td)
+        file_tester(td, option=['experiments'])

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -179,8 +179,8 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_22'].value is None
     # TODO find out why -np.Inf != -np.Inf
-    # assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max is np.Inf
-    # assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].min is -np.Inf
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max == np.Inf
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].min == -np.Inf
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23']['store']['constraint'] is None
 

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -556,3 +556,63 @@ def test_addExperimentDefinition(cal):
     assert exp_added['phase']['Fe3O4']['name'] == exp_ref['phase']['Fe3O4']['name']
     assert exp_added['phase']['Fe3O4']['scale'].value == exp_ref['phase']['Fe3O4']['scale'].value
 
+
+def test_addPhaseToExp():
+    calc = CryspyCalculator('')
+    interface = CalculatorInterface(calc)
+    interface.addExperimentDefinition(exp_path)
+    interface.addPhaseDefinition(phase_path)
+    interface.removePhaseFromExp('pd', 'Fe3O4')
+    interface.addPhaseToExp('pd', 'Fe3O4', scale=1.0)
+
+    exp_ref = interface.getExperiment('pd')
+    assert exp_ref['name'] == 'pd'
+    assert 'Fe3O4' in exp_ref['phase'].keys()
+    assert exp_ref['phase']['Fe3O4']['scale'].value == 1.0
+
+
+def test_removePhaseFromExp(cal):
+
+    cal.removePhaseFromExp('pd', 'Fe3O4')
+
+    exp_ref = cal.getExperiment('pd')
+    assert exp_ref['name'] == 'pd'
+    assert 'Fe3O4' not in exp_ref['phase'].keys()
+
+
+def test_addExperiment(cal):
+    exp2 = cal.getExperiment('pd')
+    exp2['name'] = 'Testing'
+
+    cal.addExperiment(exp2)
+
+    assert len(cal.project_dict['experiments']) == 2
+    assert 'Testing' in cal.project_dict['experiments'].keys()
+    assert cal.project_dict['experiments']['Testing']['name'] == 'Testing'
+    assert cal.project_dict['experiments']['Testing'] == exp2
+
+
+def test_removeExperiment(cal):
+    exp2 = cal.getExperiment('pd')
+    exp2['name'] = 'Testing'
+    cal.addExperiment(exp2)
+    cal.removeExperiment('pd')
+
+    assert len(cal.project_dict['experiments']) == 1
+    assert 'pd' not in cal.project_dict['experiments'].keys()
+    assert 'Testing' in cal.project_dict['experiments'].keys()
+    assert cal.project_dict['experiments']['Testing']['name'] == 'Testing'
+    assert cal.project_dict['experiments']['Testing'] == exp2
+
+
+def test_getExperiment_None(cal):
+    exp2 = cal.getExperiment('pd')
+    exp2['name'] = 'Testing'
+    cal.addExperiment(exp2)
+
+    exps = cal.getExperiment(None)
+    assert len(exps) == 2
+    assert 'pd' in exps.keys()
+    assert 'Testing' in exps.keys()
+    assert exps['Testing']['name'] == 'Testing'
+    assert exps['pd']['name'] == 'pd'

--- a/tests/easyInterface/Diffraction/test_Interface.py
+++ b/tests/easyInterface/Diffraction/test_Interface.py
@@ -1,4 +1,5 @@
 import os
+
 import numpy as np
 import pytest
 
@@ -108,7 +109,7 @@ def test_setPhasesDictFromCryspyObj(cal):
     # cell
     assert phase_dict['Fe3O4']['cell']['length_a'].value == 8.36212
     assert phase_dict['Fe3O4']['cell']['length_b']['store']['hide'] is True
-    assert phase_dict['Fe3O4']['cell']['length_c'].max == 10.034544
+    assert phase_dict['Fe3O4']['cell']['length_c']['store'].max == 10.034544
     assert phase_dict['Fe3O4']['cell']['angle_beta']['store']['error'] == 0.0
     assert phase_dict['Fe3O4']['cell']['angle_gamma']['store']['constraint'] is None
     # space_group
@@ -139,8 +140,7 @@ def test_setPhasesDictFromCryspyObj(cal):
     # Isotropic ADP
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['U_iso_or_equiv']['header'] == 'Biso'
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['U_iso_or_equiv'].value == 0.0
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['U_iso_or_equiv'].min == -1.0
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['U_iso_or_equiv'].max == 1.0
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['U_iso_or_equiv']['store'].max == 1
     assert phase_dict['Fe3O4']['atoms']['O']['U_iso_or_equiv'].value == 0.0
     assert phase_dict['Fe3O4']['atoms']['O']['U_iso_or_equiv']['store']['constraint'] is None
 
@@ -148,8 +148,7 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11']['header'] == 'U11'
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_11'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_22'].value is None
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23'].min == -np.Inf
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23'].max == np.Inf
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['ADP']['u_23']['store'].max is np.Inf
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23'].value is None
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['ADP']['u_23']['store']['constraint'] is None
 
@@ -157,8 +156,7 @@ def test_setPhasesDictFromCryspyObj(cal):
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['type'].value == 'Cani'
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_11'].value == -3.468
     assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_33'].value == -3.468
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_23'].min == -1.0
-    assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_23'].max == 1.0
+    assert phase_dict['Fe3O4']['atoms']['Fe3A']['MSP']['chi_23']['store'].max == 1
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['MSP']['chi_23'].value == 0.0
     assert phase_dict['Fe3O4']['atoms']['Fe3B']['MSP']['chi_23']['store']['refine'] is False
 
@@ -443,63 +441,3 @@ def test_addExperimentDefinition(cal):
     assert exp_added['phase']['Fe3O4']['name'] == exp_ref['phase']['Fe3O4']['name']
     assert exp_added['phase']['Fe3O4']['scale'].value == exp_ref['phase']['Fe3O4']['scale'].value
 
-
-def test_addPhaseToExp():
-    calc = CryspyCalculator('')
-    interface = CalculatorInterface(calc)
-    interface.addExperimentDefinition(exp_path)
-    interface.addPhaseDefinition(phase_path)
-    interface.removePhaseFromExp('pd', 'Fe3O4')
-    interface.addPhaseToExp('pd', 'Fe3O4', scale=1.0)
-
-    exp_ref = interface.getExperiment('pd')
-    assert exp_ref['name'] == 'pd'
-    assert 'Fe3O4' in exp_ref['phase'].keys()
-    assert exp_ref['phase']['Fe3O4']['scale'].value == 1.0
-
-
-def test_removePhaseFromExp(cal):
-
-    cal.removePhaseFromExp('pd', 'Fe3O4')
-
-    exp_ref = cal.getExperiment('pd')
-    assert exp_ref['name'] == 'pd'
-    assert 'Fe3O4' not in exp_ref['phase'].keys()
-
-
-def test_addExperiment(cal):
-    exp2 = cal.getExperiment('pd')
-    exp2['name'] = 'Testing'
-
-    cal.addExperiment(exp2)
-
-    assert len(cal.project_dict['experiments']) == 2
-    assert 'Testing' in cal.project_dict['experiments'].keys()
-    assert cal.project_dict['experiments']['Testing']['name'] == 'Testing'
-    assert cal.project_dict['experiments']['Testing'] == exp2
-
-
-def test_removeExperiment(cal):
-    exp2 = cal.getExperiment('pd')
-    exp2['name'] = 'Testing'
-    cal.addExperiment(exp2)
-    cal.removeExperiment('pd')
-
-    assert len(cal.project_dict['experiments']) == 1
-    assert 'pd' not in cal.project_dict['experiments'].keys()
-    assert 'Testing' in cal.project_dict['experiments'].keys()
-    assert cal.project_dict['experiments']['Testing']['name'] == 'Testing'
-    assert cal.project_dict['experiments']['Testing'] == exp2
-
-
-def test_getExperiment_None(cal):
-    exp2 = cal.getExperiment('pd')
-    exp2['name'] = 'Testing'
-    cal.addExperiment(exp2)
-
-    exps = cal.getExperiment(None)
-    assert len(exps) == 2
-    assert 'pd' in exps.keys()
-    assert 'Testing' in exps.keys()
-    assert exps['Testing']['name'] == 'Testing'
-    assert exps['pd']['name'] == 'pd'


### PR DESCRIPTION
Previously an error would be thrown when multiple experiments or phases have the same name. Now, if they have the same name a numeric addition will be added to the new objects name.